### PR TITLE
Sup-346 update to include puppetserver metrics for versions < 2018.1.0

### DIFF
--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -17,5 +17,31 @@ class puppet_metrics_collector::puppetserver (
     hosts         => $hosts,
     metrics_port  => $port,
   }
+  
+  if $facts['pe_server_version'] < 2018.1.0 {
+  
+    Pe_metric_curl_cron_jobs::Pe_metric <| title == 'puppetserver' |> {
+      additional_metrics => [
+        { 'name' => 'compiler.find_node',
+          'url'  => "puppetserver:name=puppetlabs.${::hostname}.compiler.find_node" },
+        { 'name' => 'puppetdb.query',
+          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.query" },
+        { 'name' => 'puppetdb.resource.search',
+          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.resource.search" },
+        { 'name' => 'puppetdb.facts.encode',
+          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.facts.encode" },
+        { 'name' => 'puppetdb.command.submit.replace facts',
+          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.replace facts" },
+        { 'name' => 'puppetdb.catalog.munge',
+          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.catalog.munge" },
+        { 'name' => 'puppetdb.command.submit.replace catalog',
+          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.replace catalog" },
+        { 'name' => 'puppetdb.report.convert_to_wire_format_hash',
+          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.report.convert_to_wire_format_hash" },
+        { 'name' => 'puppetdb.command.submit.store report',
+          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.store report" },
+      ],
+    }
+  }
 
 }

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -18,7 +18,7 @@ class puppet_metrics_collector::puppetserver (
     metrics_port  => $port,
   }
   
-  if $facts['pe_server_version'] < 2018.1.0 {
+  if $facts['pe_server_version'] < '2018.1.0' {
   
     Pe_metric_curl_cron_jobs::Pe_metric <| title == 'puppetserver' |> {
       additional_metrics => [

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -12,14 +12,6 @@ class puppet_metrics_collector::puppetserver (
     retention_days => $retention_days,
   }
 
-  puppet_metrics_collector::pe_metric { 'puppetserver' :
-    metric_ensure => $metrics_ensure,
-    hosts         => $hosts,
-    metrics_port  => $port,
-    additional_metrics => $additional_metrics,
-
-  }
-  
   if versioncmp($facts['pe_server_version'], '2018.1.0') < 0 {
     $additional_metrics = [
       { 'name' => 'compiler.find_node',
@@ -40,9 +32,15 @@ class puppet_metrics_collector::puppetserver (
         'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.report.convert_to_wire_format_hash" },
       { 'name' => 'puppetdb.command.submit.store report',
         'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.store report" },
-      ],
-    } else {
-      $additional_metrics = []
-    }
-  
- }
+      ]
+  } else {
+     $additional_metrics = []
+  }
+
+  puppet_metrics_collector::pe_metric { 'puppetserver' :
+    metric_ensure => $metrics_ensure,
+    hosts         => $hosts,
+    metrics_port  => $port,
+    additional_metrics => $additional_metrics,
+  }
+}

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -16,32 +16,33 @@ class puppet_metrics_collector::puppetserver (
     metric_ensure => $metrics_ensure,
     hosts         => $hosts,
     metrics_port  => $port,
-  }
-  
-  if $facts['pe_server_version'] < '2018.1.0' {
-  
-    Pe_metric_curl_cron_jobs::Pe_metric <| title == 'puppetserver' |> {
-      additional_metrics => [
-        { 'name' => 'compiler.find_node',
-          'url'  => "puppetserver:name=puppetlabs.${::hostname}.compiler.find_node" },
-        { 'name' => 'puppetdb.query',
-          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.query" },
-        { 'name' => 'puppetdb.resource.search',
-          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.resource.search" },
-        { 'name' => 'puppetdb.facts.encode',
-          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.facts.encode" },
-        { 'name' => 'puppetdb.command.submit.replace facts',
-          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.replace facts" },
-        { 'name' => 'puppetdb.catalog.munge',
-          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.catalog.munge" },
-        { 'name' => 'puppetdb.command.submit.replace catalog',
-          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.replace catalog" },
-        { 'name' => 'puppetdb.report.convert_to_wire_format_hash',
-          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.report.convert_to_wire_format_hash" },
-        { 'name' => 'puppetdb.command.submit.store report',
-          'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.store report" },
-      ],
-    }
-  }
+    additional_metrics => $additional_metrics,
 
-}
+  }
+  
+  if versioncmp($facts['pe_server_version'], '2018.1.0') < 0 {
+    $additional_metrics = [
+      { 'name' => 'compiler.find_node',
+        'url'  => "puppetserver:name=puppetlabs.${::hostname}.compiler.find_node" },
+      { 'name' => 'puppetdb.query',
+        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.query" },
+      { 'name' => 'puppetdb.resource.search',
+        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.resource.search" },
+      { 'name' => 'puppetdb.facts.encode',
+        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.facts.encode" },
+      { 'name' => 'puppetdb.command.submit.replace facts',
+        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.replace facts" },
+      { 'name' => 'puppetdb.catalog.munge',
+        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.catalog.munge" },
+      { 'name' => 'puppetdb.command.submit.replace catalog',
+        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.replace catalog" },
+      { 'name' => 'puppetdb.report.convert_to_wire_format_hash',
+        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.report.convert_to_wire_format_hash" },
+      { 'name' => 'puppetdb.command.submit.store report',
+        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.store report" },
+      ],
+    } else {
+      $additional_metrics = []
+    }
+  
+ }


### PR DESCRIPTION
As per Sup-346 this is to include puppetserver metrics for versions < 2018.1.0