### PR TITLE
Ensure tidy's tar captures large numbers of files

### DIFF
--- a/templates/tidy_cron.epp
+++ b/templates/tidy_cron.epp
@@ -16,6 +16,6 @@ find "$DIR" -type f -ctime +$RETENTION_DAYS -delete
 #compress files
 cd "$DIR"
 find . -type f -not -name "*.gz" -a -not -name "*.bz2" > "$DIR.tmp"
-xargs -a "$DIR.tmp" tar -zcf "$DIR/$METRICS_TYPE-$(date +%Y.%m.%d.%H.%M.%S).tar.gz"
+tar -zcf "$DIR/$METRICS_TYPE-$(date +%Y.%m.%d.%H.%M.%S).tar.gz" --files-from "$DIR.tmp"
 xargs -a "$DIR.tmp" rm
 rm "$DIR.tmp"


### PR DESCRIPTION
When a large number of files are being archived xargs might invoke
tar multiple times - overwriting the preceding tar archive. Using
the "--files-from" option to tar instead lets all files be correctly
archived.