### PR TITLE
Update metadata for current releases of stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 2.6.0 < 5.0.0"
+      "version_requirement": ">= 2.6.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Current version of stdlib is 5.2.0, and metadata is < 5.0.0