### PR TITLE
Enable splunk support

### DIFF
--- a/manifests/activemq.pp
+++ b/manifests/activemq.pp
@@ -12,6 +12,7 @@ class puppet_metrics_collector::activemq (
     scripts_dir    => $scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
+    pipe_string    => $puppet_metrics_collector::pipe_string,
   }
 
   $additional_metrics = [

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class puppet_metrics_collector (
   Array[String] $activemq_hosts                = puppet_metrics_collector::hosts_with_pe_profile('amq::broker'),
   Integer       $activemq_port                 = 8161,
   Boolean       $symlink_puppet_metrics_collector = true,
+  String        $pipe_string = Undef,
 ) {
   $scripts_dir = "${output_dir}/scripts"
   $bin_dir     = "${output_dir}/bin"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ class puppet_metrics_collector (
   Array[String] $activemq_hosts                = puppet_metrics_collector::hosts_with_pe_profile('amq::broker'),
   Integer       $activemq_port                 = 8161,
   Boolean       $symlink_puppet_metrics_collector = true,
-  String        $pipe_string = Undef,
+  String        $pipe_string = '',
 ) {
   $scripts_dir = "${output_dir}/scripts"
   $bin_dir     = "${output_dir}/bin"

--- a/manifests/orchestrator.pp
+++ b/manifests/orchestrator.pp
@@ -10,6 +10,7 @@ class puppet_metrics_collector::orchestrator (
     scripts_dir    => $puppet_metrics_collector::scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
+    pipe_string    => $puppet_metrics_collector::pipe_string,
   }
 
   puppet_metrics_collector::pe_metric { 'orchestrator' :

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -12,7 +12,7 @@ define puppet_metrics_collector::pe_metric (
   Array[Hash]               $additional_metrics = [],
   Boolean                   $ssl                = true,
 ) {
-
+  $has_pipe = ( $pipe_string ) and ($pipe_string != '')
   $metrics_output_dir = "${output_dir}/${metrics_type}"
 
   file { $metrics_output_dir :
@@ -41,7 +41,7 @@ define puppet_metrics_collector::pe_metric (
   $script_file_name = "${scripts_dir}/${metric_script_file}"
 
   # let us pipe this to a different thing entirely
-  if ($pipe_string) and ($pipe_string != '') {
+  if $has_pipe {
     $command_string = "${script_file_name} --metrics_type ${metrics_type} --print | ${pipe_string}"
   }
   else {
@@ -56,9 +56,9 @@ define puppet_metrics_collector::pe_metric (
   }
 
   # now we only install these jobs we're not piping it
-  if ( ! $pipe_string) or ($pipe_string == '') {
-    $metrics_tidy_script_path = "${scripts_dir}/${metrics_type}_metrics_tidy"
+  $metrics_tidy_script_path = "${scripts_dir}/${metrics_type}_metrics_tidy"
 
+  if ! $has_pipe {
     file { $metrics_tidy_script_path :
       ensure  => $metric_ensure,
       mode    => '0744',
@@ -75,6 +75,15 @@ define puppet_metrics_collector::pe_metric (
       hour    => fqdn_rand(3,  $metrics_type ),
       minute  => (5 * fqdn_rand(11, $metrics_type )),
       command => $metrics_tidy_script_path
+    }
+  }
+  elsif $has_pipe {
+    file { $metrics_tidy_script_path:
+      ensure => absent,
+    }
+
+    cron { "${metrics_type}_metrics_tidy" :
+      ensure => absent,
     }
   }
 

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -2,6 +2,7 @@ define puppet_metrics_collector::pe_metric (
   String                    $output_dir,
   String                    $scripts_dir,
   Integer                   $metrics_port,
+  String                    $pipe_string,
   Enum['absent', 'present'] $metric_ensure  = 'present',
   String                    $metrics_type   = $title,
   Array[String]             $hosts          = [ '127.0.0.1' ],
@@ -39,31 +40,42 @@ define puppet_metrics_collector::pe_metric (
 
   $script_file_name = "${scripts_dir}/${metric_script_file}"
 
+  # let us pipe this to a different thing entirely
+  if $pipe_string {
+    $command_string = "${script_file_name} --metrics_type ${metrics_type} --print | ${pipe_string}"
+  }
+  else {
+    $command_string = "${script_file_name} --metrics_type ${metrics_type} --output-dir ${metrics_output_dir} --no-print"
+  }
+
   cron { "${metrics_type}_metrics_collection" :
     ensure  => $metric_ensure,
-    command => "${script_file_name} --metrics_type ${metrics_type} --output-dir ${metrics_output_dir} --no-print",
+    command => $command_string,
     user    => 'root',
     minute  => $cron_minute,
   }
 
-  $metrics_tidy_script_path = "${scripts_dir}/${metrics_type}_metrics_tidy"
+  # now we only install these jobs we're not piping it
+  if ! $pipe_string {
+    $metrics_tidy_script_path = "${scripts_dir}/${metrics_type}_metrics_tidy"
 
-  file { $metrics_tidy_script_path :
-    ensure  => $metric_ensure,
-    mode    => '0744',
-    content => epp('puppet_metrics_collector/tidy_cron.epp', {
-      'metrics_output_dir' => $metrics_output_dir,
-      'metrics_type'       => $metrics_type,
-      'retention_days'     => $retention_days,
-    }),
-  }
+    file { $metrics_tidy_script_path :
+      ensure  => $metric_ensure,
+      mode    => '0744',
+      content => epp('puppet_metrics_collector/tidy_cron.epp', {
+        'metrics_output_dir' => $metrics_output_dir,
+        'metrics_type'       => $metrics_type,
+        'retention_days'     => $retention_days,
+      }),
+    }
 
-  cron { "${metrics_type}_metrics_tidy" :
-    ensure  => $metric_ensure,
-    user    => 'root',
-    hour    => fqdn_rand(3,  $metrics_type ),
-    minute  => (5 * fqdn_rand(11, $metrics_type )),
-    command => $metrics_tidy_script_path
+    cron { "${metrics_type}_metrics_tidy" :
+      ensure  => $metric_ensure,
+      user    => 'root',
+      hour    => fqdn_rand(3,  $metrics_type ),
+      minute  => (5 * fqdn_rand(11, $metrics_type )),
+      command => $metrics_tidy_script_path
+    }
   }
 
   #Cleanup old scripts

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -41,7 +41,7 @@ define puppet_metrics_collector::pe_metric (
   $script_file_name = "${scripts_dir}/${metric_script_file}"
 
   # let us pipe this to a different thing entirely
-  if $pipe_string {
+  if ($pipe_string) and ($pipe_string != '') {
     $command_string = "${script_file_name} --metrics_type ${metrics_type} --print | ${pipe_string}"
   }
   else {
@@ -56,7 +56,7 @@ define puppet_metrics_collector::pe_metric (
   }
 
   # now we only install these jobs we're not piping it
-  if ! $pipe_string {
+  if ( ! $pipe_string) or ($pipe_string == '') {
     $metrics_tidy_script_path = "${scripts_dir}/${metrics_type}_metrics_tidy"
 
     file { $metrics_tidy_script_path :

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -10,6 +10,7 @@ class puppet_metrics_collector::puppetdb (
     scripts_dir    => $puppet_metrics_collector::scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
+    pipe_string    => $puppet_metrics_collector::pipe_string,
   }
 
   $activemq_metrics = [

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -10,6 +10,7 @@ class puppet_metrics_collector::puppetserver (
     scripts_dir    => $puppet_metrics_collector::scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
+    pipe_string    => $puppet_metrics_collector::pipe_string,
   }
 
   if versioncmp($facts['pe_server_version'], '2018.1.0') < 0 {


### PR DESCRIPTION
This adds a pipe_string parameter to the pe_metrics defined type and to the top level init.pp.

It assumes the string that is passed is to an executable that can take json on standard in