### PR TITLE
Update puppetlabs-stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 2.6.0 < 6.0.0"
+      "version_requirement": ">= 2.6.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This commit updates the dependency on puppetlabs-stdlib to allow
version 6.x of the module to be used.