### PR TITLE
Skip versioncmp when pe_server_version is missing

### DIFF
--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -18,7 +18,7 @@ class puppet_metrics_collector::puppetserver (
     override_metrics_command => $override_metrics_command,
   }
 
-  if versioncmp($facts['pe_server_version'], '2018.1.0') < 0 {
+  if ($facts['pe_server_version'] =~ NotUndef) and (versioncmp($facts['pe_server_version'], '2018.1.0') < 0) {
     $additional_metrics = [
       { 'name' => 'compiler.find_node',
         'url'  => "puppetserver:name=puppetlabs.${::hostname}.compiler.find_node" },


### PR DESCRIPTION
This commit updates the version checking logic in
puppet_metrics_collector::puppetserver to skip `versioncmp()` when the
`pe_server_version` fact is missing. This change allows the class to
be applied to FOSS nodes without causing a compilation failure.