### PR TITLE
Change STDOUT.write to STDOUT.puts

### DIFF
--- a/files/json2timeseriesdb
+++ b/files/json2timeseriesdb
@@ -338,7 +338,7 @@ data_files.each do |filename|
     if $options[:host]
       $net_output.write(converted_data)
     else
-      STDOUT.write(converted_data)
+      STDOUT.puts(converted_data)
     end
   rescue => e
     STDERR.puts "ERROR: #{filename}: #{e.message}"


### PR DESCRIPTION
This allows the output to have a proper trailing newline.  Otherwise,
when processing multiple files there will be a concatenation of the last
and first lines of each file