### PR TITLE
Allow for excluding data from the metrics files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This module collects metrics provided by the status endpoints of Puppet Enterpri
 
 Install this module with `puppet module install puppetlabs-puppet_metrics_collector` or add it to your Puppetfile.
 
-To activate this module, classify your Primary Master (aka Master of Masters or MoM) with the `puppet_metrics_collector` class using your preferred classification method.
+To activate this module, classify your Primary Master (aka Master of Masters or MoM) with the `puppet_metrics_collector` class using your preferred classification method. Below is an example when using the `site.pp`.
 
 ```
 node 'master.example.com' {
@@ -48,7 +48,7 @@ node 'master.example.com' {
 node 'compilerA.example.com', 'compilerB.example.com,' {
   include puppet_metrics_collector::system
 }
-``` 
+```
 
 ### Configuration
 
@@ -112,14 +112,14 @@ The metrics come in a JSON hash on one line. In order to convert the metric file
 
 ```bash
 cd /opt/puppetlabs/puppet-metrics-collector
-for i in <service_name>/127.0.0.1/*.json; do echo "$(python -m json.tool < $i)" > $i; done
+for i in <service_name>/master.example.com/*.json; do echo "$(python -m json.tool < $i)" > $i; done
 ```
 
 You can search for useful information by performing a `grep` in the following format, run from inside the directory containing the metrics.
 
 ```
 cd /opt/puppetlabs/puppet-metrics-collector
-grep <metric_name> <service_name>/127.0.0.1/*.json
+grep <metric_name> <service_name>/master.example.com/*.json
 ```
 
 Since the metrics are compressed every night, you can only search metrics for the current day. To search older metrics, decompress the compressed files into a subdirectory of `/tmp` and run from inside that directory.
@@ -130,10 +130,10 @@ Since the metrics are compressed every night, you can only search metrics for th
 Example:
 
 ```
-grep average-free-jrubies puppetserver/127.0.0.1/*.json
-puppetserver/127.0.0.1/20170404T170501Z.json:                "average-free-jrubies": 0.9950009285369501,
-puppetserver/127.0.0.1/20170404T171001Z.json:                "average-free-jrubies": 0.9999444653324225,
-puppetserver/127.0.0.1/20170404T171502Z.json:                "average-free-jrubies": 0.9999993830655706,
+grep average-free-jrubies puppetserver/master.example.com/*.json
+puppetserver/master.example.com/20170404T170501Z.json:                "average-free-jrubies": 0.9950009285369501,
+puppetserver/master.example.com/20170404T171001Z.json:                "average-free-jrubies": 0.9999444653324225,
+puppetserver/master.example.com/20170404T171502Z.json:                "average-free-jrubies": 0.9999993830655706,
 ```
 
 #### Grepping PuppetDB Metrics
@@ -141,25 +141,25 @@ puppetserver/127.0.0.1/20170404T171502Z.json:                "average-free-jrubi
 Example:
 
 ```
-grep queue_depth puppetdb/127.0.0.1/*.json
-puppetdb/127.0.0.1/20170404T170501Z.json:            "queue_depth": 0,
-puppetdb/127.0.0.1/20170404T171001Z.json:            "queue_depth": 0,
-puppetdb/127.0.0.1/20170404T171502Z.json:            "queue_depth": 0,
+grep queue_depth puppetdb/master.example.com/*.json
+puppetdb/master.example.com/20170404T170501Z.json:            "queue_depth": 0,
+puppetdb/master.example.com/20170404T171001Z.json:            "queue_depth": 0,
+puppetdb/master.example.com/20170404T171502Z.json:            "queue_depth": 0,
 ```
 
 Example for PE 2016.5 and older:
 
 ```
-grep Cursor puppetdb/127.0.0.1/*.json
-puppetdb/127.0.0.1/20170404T171001Z.json:          "CursorMemoryUsage": 0,
-puppetdb/127.0.0.1/20170404T171001Z.json:          "CursorFull": false,
-puppetdb/127.0.0.1/20170404T171001Z.json:          "CursorPercentUsage": 0,
-puppetdb/127.0.0.1/20170404T171502Z.json:          "CursorMemoryUsage": 0,
-puppetdb/127.0.0.1/20170404T171502Z.json:          "CursorFull": false,
-puppetdb/127.0.0.1/20170404T171502Z.json:          "CursorPercentUsage": 0,
-puppetdb/127.0.0.1/20170404T172002Z.json:          "CursorMemoryUsage": 0,
-puppetdb/127.0.0.1/20170404T172002Z.json:          "CursorFull": false,
-puppetdb/127.0.0.1/20170404T172002Z.json:          "CursorPercentUsage": 0,
+grep Cursor puppetdb/master.example.com/*.json
+puppetdb/master.example.com/20170404T171001Z.json:          "CursorMemoryUsage": 0,
+puppetdb/master.example.com/20170404T171001Z.json:          "CursorFull": false,
+puppetdb/master.example.com/20170404T171001Z.json:          "CursorPercentUsage": 0,
+puppetdb/master.example.com/20170404T171502Z.json:          "CursorMemoryUsage": 0,
+puppetdb/master.example.com/20170404T171502Z.json:          "CursorFull": false,
+puppetdb/master.example.com/20170404T171502Z.json:          "CursorPercentUsage": 0,
+puppetdb/master.example.com/20170404T172002Z.json:          "CursorMemoryUsage": 0,
+puppetdb/master.example.com/20170404T172002Z.json:          "CursorFull": false,
+puppetdb/master.example.com/20170404T172002Z.json:          "CursorPercentUsage": 0,
 ```
 
 
@@ -191,14 +191,14 @@ Example:
 
 ```
 /opt/puppetlabs/puppet-metrics-collector/puppetserver
-├── 127.0.0.1
+├── master.example.com
 │   ├── 20170404T020001Z.json
 │   ├── ...
 │   ├── 20170404T170501Z.json
 │   └── 20170404T171001Z.json
 └── puppetserver-2017.04.04.02.00.01.tar.bz2
 /opt/puppetlabs/puppet-metrics-collector/puppetdb
-└── 127.0.0.1
+└── master.example.com
 │   ├── 20170404T020001Z.json
 │   ├── ...
 │   ├── 20170404T170501Z.json
@@ -336,7 +336,7 @@ If the future parser is enabled, globally or in the environment, the following c
 
 ```
 class { 'puppet_metrics_collector':
-  output_dir => '/opt/puppet/puppet_metrics_collector'
+  output_dir => '/opt/puppet/puppet-metrics-collector'
 }
 ```
 
@@ -344,5 +344,5 @@ Otherwise, use the following commands.
 
 ```
 puppet module install puppetlabs-puppet_metrics_collector --modulepath /tmp;
-puppet apply -e "class { 'puppet_metrics_collector' : output_dir => '/opt/puppet/puppet_metrics_collector' }"  --modulepath /tmp --parser=future
+puppet apply -e "class { 'puppet_metrics_collector' : output_dir => '/opt/puppet/puppet-metrics-collector' }"  --modulepath /tmp --parser=future
 ```

--- a/README.md
+++ b/README.md
@@ -108,6 +108,13 @@ Optional String: Allows you to override the command that is run to gather metric
 
 ### Grepping Metrics
 
+The metrics come in a JSON hash on one line. In order to convert the metric files into a pretty format, they can be processed with `python -m json.tool` like below.
+
+```bash
+cd /opt/puppetlabs/puppet-metrics-collector
+for i in <service_name>/127.0.0.1/*.json; do echo "$(python -m json.tool < $i)" > $i; done
+```
+
 You can search for useful information by performing a `grep` in the following format, run from inside the directory containing the metrics.
 
 ```

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -45,6 +45,7 @@ METRICS    = config['additional_metrics']
 CLIENTCERT = config['clientcert']
 PE_VERSION = config['pe_version']
 SSL        = coalesce(options[:ssl], config['ssl'], true)
+EXCLUDES   = config['excludes']
 
 $error_array = []
 
@@ -144,6 +145,19 @@ def retrieve_additional_metrics(host,port,metrics,pe_version, ssl)
   return metrics_array
 end
 
+def filter_metrics(dataset, filters)
+  return dataset if filters.empty?
+
+  case dataset
+  when Hash
+    dataset = dataset.inject({}) {|m, (k, v)| m[k] = filter_metrics(v,filters) unless filters.include? k ; m }
+  when Array
+    dataset.map! {|e| filter_metrics(e,filters)}
+  end
+
+  return dataset
+end
+
 filename = Time.now.utc.strftime('%Y%m%dT%H%M%SZ') + '.json'
 
 HOSTS.each do |host|
@@ -171,7 +185,8 @@ HOSTS.each do |host|
     dataset['servers'][hostkey][METRICS_TYPE]['api-query-start'] = timestamp.utc.iso8601
     dataset['servers'][hostkey][METRICS_TYPE]['api-query-duration'] = Time.now - timestamp
 
-    json_dataset = JSON.pretty_generate(dataset)
+    filtered_dataset = filter_metrics(dataset, EXCLUDES)
+    json_dataset = JSON.pretty_generate(filtered_dataset)
 
     unless OUTPUT_DIR.nil? then
       Dir.chdir(OUTPUT_DIR) do

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -186,7 +186,7 @@ HOSTS.each do |host|
     dataset['servers'][hostkey][METRICS_TYPE]['api-query-duration'] = Time.now - timestamp
 
     filtered_dataset = filter_metrics(dataset, EXCLUDES)
-    json_dataset = JSON.pretty_generate(filtered_dataset)
+    json_dataset = JSON.generate(filtered_dataset)
 
     unless OUTPUT_DIR.nil? then
       Dir.chdir(OUTPUT_DIR) do

--- a/functions/version_based_excludes.pp
+++ b/functions/version_based_excludes.pp
@@ -1,0 +1,17 @@
+function puppet_metrics_collector::version_based_excludes(
+  String[1] $metrics_type,
+) >> Array[String] {
+  case $metrics_type {
+    'puppetserver': {
+      $excludes = versioncmp($facts['pe_server_version'], '2017.3.0') >= 0 ? {
+        true    => ['file-sync-storage-service','pe-puppet-profiler','pe-master','pe-jruby-metrics'],
+        default => ['file-sync-storage-service'],
+      }
+    }
+    default: {
+      $excludes = []
+    }
+  }
+
+  return $excludes
+}

--- a/functions/version_based_excludes.pp
+++ b/functions/version_based_excludes.pp
@@ -3,7 +3,7 @@ function puppet_metrics_collector::version_based_excludes(
 ) >> Array[String] {
   case $metrics_type {
     'puppetserver': {
-      $excludes = versioncmp($facts['pe_server_version'], '2017.3.0') >= 0 ? {
+      $excludes = ($facts['pe_server_version'] =~ NotUndef and versioncmp($facts['pe_server_version'], '2017.3.0') >= 0) ? {
         true    => ['file-sync-storage-service','pe-puppet-profiler','pe-master','pe-jruby-metrics'],
         default => ['file-sync-storage-service'],
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,9 @@ class puppet_metrics_collector (
   Optional[Integer] $metrics_server_port      = undef,
   Optional[String]  $metrics_server_db_name   = undef,
   Optional[String]  $override_metrics_command = undef,
+  Optional[Array[String]] $puppetserver_excludes = ['pe-puppet-profiler', 'file-sync-storage-service'],
+  Optional[Array[String]] $puppetdb_excludes     = undef,
+  Optional[Array[String]] $orchestrator_excludes = undef,
 ) {
   $scripts_dir = "${output_dir}/scripts"
   $bin_dir     = "${output_dir}/bin"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ class puppet_metrics_collector (
   Optional[Integer] $metrics_server_port      = undef,
   Optional[String]  $metrics_server_db_name   = undef,
   Optional[String]  $override_metrics_command = undef,
-  Optional[Array[String]] $puppetserver_excludes = ['pe-puppet-profiler', 'file-sync-storage-service'],
+  Optional[Array[String]] $puppetserver_excludes = undef,
   Optional[Array[String]] $puppetdb_excludes     = undef,
   Optional[Array[String]] $orchestrator_excludes = undef,
 ) {

--- a/manifests/orchestrator.pp
+++ b/manifests/orchestrator.pp
@@ -8,6 +8,7 @@ class puppet_metrics_collector::orchestrator (
   Optional[String]  $metrics_server_hostname = $puppet_metrics_collector::metrics_server_hostname,
   Optional[Integer] $metrics_server_port     = $puppet_metrics_collector::metrics_server_port,
   Optional[String]  $metrics_server_db_name  = $puppet_metrics_collector::metrics_server_db_name,
+  Optional[Array[String]] $excludes          = $puppet_metrics_collector::orchestrator_excludes,
   ) {
   Puppet_metrics_collector::Pe_metric {
     output_dir     => $puppet_metrics_collector::output_dir,
@@ -24,5 +25,6 @@ class puppet_metrics_collector::orchestrator (
     metrics_server_hostname => $metrics_server_hostname,
     metrics_server_port     => $metrics_server_port,
     metrics_server_db_name  => $metrics_server_db_name,
+    excludes                => $excludes,
   }
 }

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -10,6 +10,7 @@ define puppet_metrics_collector::pe_metric (
   String                    $metric_script_file = 'tk_metrics',
   Array[Hash]               $additional_metrics = [],
   Boolean                   $ssl                = true,
+  Array[String]             $excludes           = [],
   Optional[Enum['influxdb','graphite','splunk_hec']] $metrics_server_type = undef,
   Optional[String]          $metrics_server_hostname  = undef,
   Optional[Integer]         $metrics_server_port      = undef,
@@ -36,6 +37,7 @@ define puppet_metrics_collector::pe_metric (
     'clientcert'         => $::clientcert,
     'pe_version'         => $facts['pe_server_version'],
     'ssl'                => $ssl,
+    'excludes'           => $excludes,
   }
 
   file { "${scripts_dir}/${metrics_type}_config.yaml" :

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -10,7 +10,7 @@ define puppet_metrics_collector::pe_metric (
   String                    $metric_script_file = 'tk_metrics',
   Array[Hash]               $additional_metrics = [],
   Boolean                   $ssl                = true,
-  Array[String]             $excludes           = [],
+  Array[String]             $excludes           = puppet_metrics_collector::version_based_excludes($title),
   Optional[Enum['influxdb','graphite','splunk_hec']] $metrics_server_type = undef,
   Optional[String]          $metrics_server_hostname  = undef,
   Optional[Integer]         $metrics_server_port      = undef,

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -9,6 +9,7 @@ class puppet_metrics_collector::puppetdb (
   Optional[Integer] $metrics_server_port      = $puppet_metrics_collector::metrics_server_port,
   Optional[String]  $metrics_server_db_name   = $puppet_metrics_collector::metrics_server_db_name,
   Optional[String]  $override_metrics_command = $puppet_metrics_collector::override_metrics_command,
+  Optional[Array[String]] $excludes           = $puppet_metrics_collector::puppetdb_excludes,
   ) {
   Puppet_metrics_collector::Pe_metric {
     output_dir               => $puppet_metrics_collector::output_dir,
@@ -195,5 +196,6 @@ class puppet_metrics_collector::puppetdb (
     metrics_server_hostname => $metrics_server_hostname,
     metrics_server_port     => $metrics_server_port,
     metrics_server_db_name  => $metrics_server_db_name,
+    excludes                => $excludes,
   }
 }

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -9,6 +9,7 @@ class puppet_metrics_collector::puppetserver (
   Optional[Integer] $metrics_server_port     = $puppet_metrics_collector::metrics_server_port,
   Optional[String]  $metrics_server_db_name  = $puppet_metrics_collector::metrics_server_db_name,
   Optional[String]  $override_metrics_command = $puppet_metrics_collector::override_metrics_command,
+  Optional[Array[String]] $excludes           = $puppet_metrics_collector::puppetserver_excludes,
   ) {
   Puppet_metrics_collector::Pe_metric {
     output_dir     => $puppet_metrics_collector::output_dir,
@@ -52,5 +53,6 @@ class puppet_metrics_collector::puppetserver (
     metrics_server_hostname => $metrics_server_hostname,
     metrics_server_port     => $metrics_server_port,
     metrics_server_db_name  => $metrics_server_db_name,
+    excludes                => $excludes,
   }
 }


### PR DESCRIPTION
Prior to this PR, there was no mechanism for filtering out metrics
from the json files. This PR adds filter capabilities and defaults
to removing the `pe-puppet-profiler` and `file-sync-storage-service`
hashes from the `puppetserver` metrics.