### PR TITLE
(PE-27794) collect data from ace and bolt (puma) services

### DIFF
--- a/files/puma_metrics
+++ b/files/puma_metrics
@@ -42,24 +42,37 @@ OUTPUT_DIR = options[:output_dir]
 HOSTS      = config['hosts']
 PORT       = coalesce(options[:metrics_port], config['metrics_port'])
 METRICS    = config['additional_metrics']
-CLIENTCERT = config['clientcert']
 PE_VERSION = config['pe_version']
 SSL        = coalesce(options[:ssl], config['ssl'], true)
 EXCLUDES   = config['excludes']
 
+if SSL
+  CERTNAME = `puppet config print certname`.chomp
+  SSLDIR   = `puppet config print ssldir`.chomp
+end
+
 $error_array = []
 
+# Change to reflect the version of PE with Puma metrics endpoints.
 exit if Gem::Version.new(PE_VERSION) < Gem::Version.new('2019.4.0')
 
 def setup_connection(url, ssl)
   uri  = URI.parse(url)
   http = Net::HTTP.new(uri.host, uri.port)
+
   if ssl then
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    # PE Puma services serve metrics from endpoints requiring a client certificate.
+    # If https://github.com/puma/puma/pull/2098 is merged into the Puma used by PE,
+    # we can collect metrics from /stats and /gc-stats without a client certificate.
+    http.ca_path = "#{SSLDIR}/ca"
+    http.ca_file = "#{SSLDIR}/certs/ca.pem"
+    http.cert = OpenSSL::X509::Certificate.new(File.read("#{SSLDIR}/certs/#{CERTNAME}.pem"))
+    http.key = OpenSSL::PKey::RSA.new(File.read("#{SSLDIR}/private_keys/#{CERTNAME}.pem"))
   end
 
-  return http,uri
+  return http, uri
 end
 
 def get_endpoint(url,ssl)
@@ -81,17 +94,20 @@ def generate_host_url(host, port, ssl)
   host_url = "#{protocol}://#{host}:#{port}"
 end
 
+# If https://github.com/puma/puma/pull/2098 is merged into the Puma used by PE,
+# we can collect metrics from /stats and /gc-stats without a client certificate.
+
 def get_status_endpoint(host, port, ssl)
   host_url = generate_host_url(host, port, ssl)
 
-  status_endpoint = "#{host_url}/stats"
+  status_endpoint = "#{host_url}/admin/status"
   status_output   = get_endpoint(status_endpoint,ssl)
 end
 
 def get_gc_status_endpoint(host, port, ssl)
   host_url = generate_host_url(host, port, ssl)
 
-  status_endpoint = "#{host_url}/gc-stats"
+  status_endpoint = "#{host_url}/admin/gc_stat"
   status_output   = get_endpoint(status_endpoint,ssl)
 end
 

--- a/files/puma_metrics
+++ b/files/puma_metrics
@@ -53,8 +53,7 @@ end
 
 $error_array = []
 
-# Change to reflect the version of PE with Puma metrics endpoints.
-exit if Gem::Version.new(PE_VERSION) < Gem::Version.new('2019.4.0')
+exit if Gem::Version.new(PE_VERSION) < Gem::Version.new('2019.3.0')
 
 def setup_connection(url, ssl)
   uri  = URI.parse(url)

--- a/files/puma_metrics.rb
+++ b/files/puma_metrics.rb
@@ -1,0 +1,145 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+
+require "net/https"
+require "json"
+require "uri"
+require 'time'
+require 'optparse'
+require 'yaml'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: puma_metrics [options]"
+
+  opts.on('-p', '--[no-]print', 'Print to stdout') { |p| options[:print] = p }
+  opts.on('-m [TYPE]', '--metrics_type [TYPE]', 'Type of metric to collect') { |v| options[:metrics_type] = v }
+  opts.on('-o [DIR]', '--output-dir [DIR]', 'Directory to save output to') { |o| options[:output_dir] = o }
+  opts.on('--metrics_port [PORT]', 'The port the metrics service runs on') { |port| options[:metrics_port] = port }
+  opts.on('--[no-]ssl', 'Whether or not to use SSL when gather metrics') { |ssl| options[:ssl] = ssl }
+end.parse!
+
+if options[:metrics_type].nil? then
+  STDERR.puts '--metrics_type (-m) is a required argument'
+  exit 1
+end
+
+METRICS_TYPE = options[:metrics_type]
+config = YAML.load_file(File.join(File.dirname(File.expand_path(__FILE__)),"#{METRICS_TYPE}_config.yaml"))
+
+def coalesce ( opt1, opt2, default=nil )
+  if opt1.nil? then
+    if opt2.nil? then
+      default
+    else
+      opt2
+    end
+  else
+    opt1
+  end
+end
+
+OUTPUT_DIR = options[:output_dir]
+HOSTS      = config['hosts']
+PORT       = coalesce(options[:metrics_port], config['metrics_port'])
+METRICS    = config['additional_metrics']
+CLIENTCERT = config['clientcert']
+PE_VERSION = config['pe_version']
+SSL        = coalesce(options[:ssl], config['ssl'], true)
+EXCLUDES   = config['excludes']
+
+$error_array = []
+
+exit if Gem::Version.new(PE_VERSION) < Gem::Version.new('2019.4.0')
+
+def setup_connection(url, ssl)
+  uri  = URI.parse(url)
+  http = Net::HTTP.new(uri.host, uri.port)
+  if ssl then
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+  end
+
+  return http,uri
+end
+
+def get_endpoint(url,ssl)
+  http,uri = setup_connection(url,ssl)
+
+  data = JSON.parse(http.get(uri.request_uri).body)
+rescue Exception => e
+    $error_array << "#{e}"
+    data = {}
+end
+
+def generate_host_url(host, port, ssl)
+  if ssl then
+    protocol = 'https'
+  else
+    protocol = 'http'
+  end
+
+  host_url = "#{protocol}://#{host}:#{port}"
+end
+
+def get_status_endpoint(host, port, ssl)
+  host_url = generate_host_url(host, port, ssl)
+
+  status_endpoint = "#{host_url}/stats"
+  status_output   = get_endpoint(status_endpoint,ssl)
+end
+
+def get_gc_status_endpoint(host, port, ssl)
+  host_url = generate_host_url(host, port, ssl)
+
+  status_endpoint = "#{host_url}/gc-stats"
+  status_output   = get_endpoint(status_endpoint,ssl)
+end
+
+def filter_metrics(dataset, filters)
+  return dataset if filters.empty?
+
+  case dataset
+  when Hash
+    dataset = dataset.inject({}) {|m, (k, v)| m[k] = filter_metrics(v,filters) unless filters.include? k ; m }
+  when Array
+    dataset.map! {|e| filter_metrics(e,filters)}
+  end
+
+  return dataset
+end
+
+filename = Time.now.utc.strftime('%Y%m%dT%H%M%SZ') + '.json'
+
+HOSTS.each do |host|
+  begin
+    timestamp = Time.now
+    dataset = {'timestamp' => timestamp.utc.iso8601, 'servers' => {}}
+    hostkey = host.gsub('.', '-')
+
+    status_output = get_status_endpoint(host, PORT, SSL)
+    dataset['servers'][hostkey] = {METRICS_TYPE => status_output}
+
+    gc_status_output = get_gc_status_endpoint(host, PORT, SSL)
+    dataset['servers'][hostkey][METRICS_TYPE]['gc_stats'] = gc_status_output
+
+    dataset['servers'][hostkey][METRICS_TYPE]['error'] = $error_array
+    dataset['servers'][hostkey][METRICS_TYPE]['error_count'] = $error_array.count
+    dataset['servers'][hostkey][METRICS_TYPE]['api-query-start'] = timestamp.utc.iso8601
+    dataset['servers'][hostkey][METRICS_TYPE]['api-query-duration'] = Time.now - timestamp
+
+    filtered_dataset = filter_metrics(dataset, EXCLUDES)
+    json_dataset = JSON.generate(filtered_dataset)
+
+    unless OUTPUT_DIR.nil? then
+      Dir.chdir(OUTPUT_DIR) do
+        Dir.mkdir(host) unless File.exist?(host)
+        File.open(File.join(host, filename), 'w') do |file|
+          file.write(json_dataset)
+        end
+      end
+    end
+    if options[:print] != false then
+      STDOUT.write(json_dataset)
+    end
+  end
+end

--- a/functions/hosts_with_pe_profile.pp
+++ b/functions/hosts_with_pe_profile.pp
@@ -14,6 +14,8 @@
 # Returns ['127.0.0.1'] when PuppetDB returns no hosts.
 
 function puppet_metrics_collector::hosts_with_pe_profile($profile) {
+  # storeconfigs is used here to determine if PuppetDB is available to query.
+  # See: https://github.com/puppetlabs/puppet-enterprise-modules/blob/master/docs/pe-modules-next-discussion-outline.txt
   if $settings::storeconfigs {
     $_profile = capitalize($profile)
     $hosts = puppetdb_query("resources[certname] {

--- a/manifests/ace.pp
+++ b/manifests/ace.pp
@@ -1,0 +1,30 @@
+class puppet_metrics_collector::ace (
+  Integer       $collection_frequency = $puppet_metrics_collector::collection_frequency,
+  Integer       $retention_days       = $puppet_metrics_collector::retention_days,
+  String        $metrics_ensure       = $puppet_metrics_collector::ace_metrics_ensure,
+  Array[String] $hosts                = $puppet_metrics_collector::ace_hosts,
+  Integer       $port                 = $puppet_metrics_collector::ace_port,
+  Optional[Enum['influxdb','graphite','splunk_hec']] $metrics_server_type = $puppet_metrics_collector::metrics_server_type,
+  Optional[String]  $metrics_server_hostname = $puppet_metrics_collector::metrics_server_hostname,
+  Optional[Integer] $metrics_server_port     = $puppet_metrics_collector::metrics_server_port,
+  Optional[String]  $metrics_server_db_name  = $puppet_metrics_collector::metrics_server_db_name,
+  Optional[Array[String]] $excludes          = $puppet_metrics_collector::ace_excludes,
+  ) {
+  Puppet_metrics_collector::Puma_metric {
+    output_dir     => $puppet_metrics_collector::output_dir,
+    scripts_dir    => $puppet_metrics_collector::scripts_dir,
+    cron_minute    => "*/${collection_frequency}",
+    retention_days => $retention_days,
+  }
+
+  puppet_metrics_collector::puma_metric { 'ace' :
+    metric_ensure           => $metrics_ensure,
+    hosts                   => $hosts,
+    metrics_port            => $port,
+    metrics_server_type     => $metrics_server_type,
+    metrics_server_hostname => $metrics_server_hostname,
+    metrics_server_port     => $metrics_server_port,
+    metrics_server_db_name  => $metrics_server_db_name,
+    excludes                => $excludes,
+  }
+}

--- a/manifests/bolt.pp
+++ b/manifests/bolt.pp
@@ -1,0 +1,30 @@
+class puppet_metrics_collector::bolt (
+  Integer       $collection_frequency = $puppet_metrics_collector::collection_frequency,
+  Integer       $retention_days       = $puppet_metrics_collector::retention_days,
+  String        $metrics_ensure       = $puppet_metrics_collector::bolt_metrics_ensure,
+  Array[String] $hosts                = $puppet_metrics_collector::bolt_hosts,
+  Integer       $port                 = $puppet_metrics_collector::bolt_port,
+  Optional[Enum['influxdb','graphite','splunk_hec']] $metrics_server_type = $puppet_metrics_collector::metrics_server_type,
+  Optional[String]  $metrics_server_hostname = $puppet_metrics_collector::metrics_server_hostname,
+  Optional[Integer] $metrics_server_port     = $puppet_metrics_collector::metrics_server_port,
+  Optional[String]  $metrics_server_db_name  = $puppet_metrics_collector::metrics_server_db_name,
+  Optional[Array[String]] $excludes          = $puppet_metrics_collector::bolt_excludes,
+  ) {
+  Puppet_metrics_collector::Puma_metric {
+    output_dir     => $puppet_metrics_collector::output_dir,
+    scripts_dir    => $puppet_metrics_collector::scripts_dir,
+    cron_minute    => "*/${collection_frequency}",
+    retention_days => $retention_days,
+  }
+
+  puppet_metrics_collector::puma_metric { 'bolt' :
+    metric_ensure           => $metrics_ensure,
+    hosts                   => $hosts,
+    metrics_port            => $port,
+    metrics_server_type     => $metrics_server_type,
+    metrics_server_hostname => $metrics_server_hostname,
+    metrics_server_port     => $metrics_server_port,
+    metrics_server_db_name  => $metrics_server_db_name,
+    excludes                => $excludes,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,12 @@ class puppet_metrics_collector (
   String        $orchestrator_metrics_ensure   = 'present',
   Array[String] $orchestrator_hosts            = puppet_metrics_collector::hosts_with_pe_profile('orchestrator'),
   Integer       $orchestrator_port             = 8143,
+  String        $ace_metrics_ensure            = 'present',
+  Array[String] $ace_hosts                     = puppet_metrics_collector::hosts_with_pe_profile('ace_server'),
+  Integer       $ace_port                      = 44633,
+  String        $bolt_metrics_ensure           = 'present',
+  Array[String] $bolt_hosts                    = puppet_metrics_collector::hosts_with_pe_profile('bolt_server'),
+  Integer       $bolt_port                     = 62658,
   String        $activemq_metrics_ensure       = 'absent',
   Array[String] $activemq_hosts                = puppet_metrics_collector::hosts_with_pe_profile('amq::broker'),
   Integer       $activemq_port                 = 8161,
@@ -23,12 +29,20 @@ class puppet_metrics_collector (
   Optional[Array[String]] $puppetserver_excludes = undef,
   Optional[Array[String]] $puppetdb_excludes     = undef,
   Optional[Array[String]] $orchestrator_excludes = undef,
+  Optional[Array[String]] $ace_excludes          = undef,
+  Optional[Array[String]] $bolt_excludes         = undef,
 ) {
   $scripts_dir = "${output_dir}/scripts"
   $bin_dir     = "${output_dir}/bin"
 
   file { [ $output_dir, $scripts_dir, $bin_dir] :
     ensure => directory,
+  }
+
+  file { "${scripts_dir}/puma_metrics" :
+    ensure => present,
+    mode   => '0755',
+    source => 'puppet:///modules/puppet_metrics_collector/puma_metrics'
   }
 
   file { "${scripts_dir}/tk_metrics" :
@@ -66,6 +80,8 @@ class puppet_metrics_collector (
   include puppet_metrics_collector::puppetserver
   include puppet_metrics_collector::puppetdb
   include puppet_metrics_collector::orchestrator
+  include puppet_metrics_collector::ace
+  include puppet_metrics_collector::bolt
   include puppet_metrics_collector::activemq
 
   # LEGACY CLEANUP

--- a/manifests/puma_metric.pp
+++ b/manifests/puma_metric.pp
@@ -1,0 +1,112 @@
+define puppet_metrics_collector::puma_metric (
+  String                    $output_dir,
+  String                    $scripts_dir,
+  Integer                   $metrics_port,
+  Enum['absent', 'present'] $metric_ensure  = 'present',
+  String                    $metrics_type   = $title,
+  Array[String]             $hosts          = [ '127.0.0.1' ],
+  String                    $cron_minute    = '*/5',
+  Integer                   $retention_days = 90,
+  String                    $metric_script_file = 'puma_metrics',
+  Array[Hash]               $additional_metrics = [],
+  Boolean                   $ssl                = true,
+  Array[String]             $excludes           = puppet_metrics_collector::version_based_excludes($title),
+  Optional[Enum['influxdb','graphite','splunk_hec']] $metrics_server_type = undef,
+  Optional[String]          $metrics_server_hostname  = undef,
+  Optional[Integer]         $metrics_server_port      = undef,
+  Optional[String]          $metrics_server_db_name   = undef,
+  Optional[String]          $override_metrics_command = undef,
+) {
+
+  $metrics_output_dir = "${output_dir}/${metrics_type}"
+
+  $_metric_ensure = $metric_ensure ? {
+      'present' => directory,
+      'absent'  => absent,
+    }
+
+  file { $metrics_output_dir :
+    ensure => $_metric_ensure,
+  }
+
+  $config_hash = {
+    'hosts'              => $hosts.sort(),
+    'metrics_type'       => $metrics_type,
+    'metrics_port'       => $metrics_port,
+    'additional_metrics' => $additional_metrics,
+    'clientcert'         => $::clientcert,
+    'pe_version'         => $facts['pe_server_version'],
+    'ssl'                => $ssl,
+    'excludes'           => $excludes,
+  }
+
+  file { "${scripts_dir}/${metrics_type}_config.yaml" :
+    ensure  => $metric_ensure,
+    mode    => '0644',
+    content => $config_hash.puppet_metrics_collector::to_yaml(),
+  }
+
+  $script_file_name = "${scripts_dir}/${metric_script_file}"
+  $conversion_script_file_name = "${scripts_dir}/json2timeseriesdb"
+
+  if empty($override_metrics_command){
+    $metrics_base_command = "${script_file_name} --metrics_type ${metrics_type} --output-dir ${metrics_output_dir}"
+
+    if !empty($metrics_server_type) {
+      $server_hostname = $metrics_server_hostname
+      $server_port     = $metrics_server_port
+      $server_type     = $metrics_server_type
+      $server_db       = $metrics_server_db_name
+
+      if empty($server_db) and $server_type == 'influxdb'  {
+        fail( 'When using an influxdb server you must provide the db_name to store metrics in' )
+      }
+
+      $local_metrics_command = "${metrics_base_command} | ${conversion_script_file_name} --netcat ${server_hostname} --convert-to ${server_type}"
+
+      $port_metrics_command = empty($server_port) ? {
+        false => "${local_metrics_command} --port ${server_port}",
+        true  => $local_metrics_command,
+      }
+
+      $metrics_command = $server_type ? {
+        'influxdb' => "${port_metrics_command} --influx-db ${server_db} > /dev/null",
+        'graphite' => "${port_metrics_command} > /dev/null",
+        # We use only the base metrics command for splunk_hec server type
+        'splunk_hec' => "${metrics_base_command} | /opt/puppetlabs/bin/puppet splunk_hec --sourcetype puppet:metrics --pe_metrics > /dev/null",
+        default    => "${port_metrics_command} > /dev/null",
+      }
+    } else {
+      $metrics_command = "${metrics_base_command} --no-print"
+    }
+  } else {
+    $metrics_command = $override_metrics_command
+  }
+
+  cron { "${metrics_type}_metrics_collection" :
+    ensure  => $metric_ensure,
+    command => $metrics_command,
+    user    => 'root',
+    minute  => $cron_minute,
+  }
+
+  $metrics_tidy_script_path = "${scripts_dir}/${metrics_type}_metrics_tidy"
+
+  file { $metrics_tidy_script_path :
+    ensure  => $metric_ensure,
+    mode    => '0744',
+    content => epp('puppet_metrics_collector/tidy_cron.epp', {
+      'metrics_output_dir' => $metrics_output_dir,
+      'metrics_type'       => $metrics_type,
+      'retention_days'     => $retention_days,
+    }),
+  }
+
+  cron { "${metrics_type}_metrics_tidy" :
+    ensure  => $metric_ensure,
+    user    => 'root',
+    hour    => fqdn_rand(3,  $metrics_type ),
+    minute  => (5 * fqdn_rand(11, $metrics_type )),
+    command => $metrics_tidy_script_path
+  }
+}


### PR DESCRIPTION
With this commit, collect ace and bolt data: metrics and gc metrics.

Since ace-server and bolt-server are installed on the orchestrator hosts,
this reuses $orchestrator_hosts in init.pp.

Collects nothing unless PE is newer than 2019.4.0, in puma_metrics.rb.
Modify to match when ace and bolt status endpoints are enabled in PE.