### PR TITLE
(maint) sync up what bolt and ace are called

### DIFF
--- a/files/generate_system_metrics
+++ b/files/generate_system_metrics
@@ -273,12 +273,12 @@ module SystemMetrics
       when /^puma$/
         case command_full
         when /bolt-server/
-          return "bolt-server"
+          return "bolt"
         when /ace-server/
           if command_full =~ /ruby/
             return "ace-cleanup"
           end
-          return "ace-server"
+          return "ace"
         end
       when /^nginx$/
         return "nginx"


### PR DESCRIPTION
new metrics from bolt and ace call themselves bolt and ace, where as thier processes are called ace-server and bolt-server.  Updated the generate_system_metrics to change to ace and bolt for consistency.  Makes the graphite2json scripts which process those names cleaner.