### PR TITLE
(SLV-771) Fix bug where process data is missed

### DIFF
--- a/files/generate_system_metrics
+++ b/files/generate_system_metrics
@@ -232,6 +232,7 @@ module SystemMetrics
       # add the pid that was the key as a data item
       unknown_count = 0
       processes_to_monitor.each do |k, v|
+        next unless data_hash.key?(k)
         comm_identifier = determine_relevant_command_name(v,data_hash[k]["command_pidstat"])
         if comm_identifier == "unknown" #needs to be unique so adding a counter
           unknown_count += 1
@@ -409,7 +410,7 @@ if $PROGRAM_NAME == __FILE__
   FILE_INTERVAL_DEFAULT = 60 * 5
   POLLING_INTERVAL_DEFAULT = 1
   METRIC_TYPE_DEFAULT = "system_cpu"
-  PROCESS_EXPRESSION_DEFAULT = "/opt/puppetlabs|puma.*/etc/puppetlabs"
+  PROCESS_EXPRESSION_DEFAULT = "/opt/puppetlabs.*(java|postgres)|puma.*/etc/puppetlabs/(ace|bolt)"
   METRICS_DIR_DEFAULT = "/opt/puppetlabs/puppet-metrics-collector"
 
   DESCRIPTION = <<-DESCRIPTION

--- a/files/generate_system_metrics
+++ b/files/generate_system_metrics
@@ -18,11 +18,11 @@ require "fileutils"
 #
 # Example execution
 # generate_system_metrics --metric_type system_cpu --file_interval 300 --polling_interval 1
-#                         --metrics_dir /opt/puppetlabs/puppet-metrics-collector
+#                         --metrics_dir <path to puppet-metrics-collector data>
 # or
 # generate_system_metrics --metric_type processes --file_interval 300 --polling_interval 1
-#                         --process_expression '/opt/puppetlabs|puma.*/etc/puppetlabs'
-#                         --metrics_dir /opt/puppetlabs/puppet-metrics-collector
+#                         --process_expression <custom expression>
+#                         --metrics_dir <path to puppet-metrics-collector data>
 
 # General namespace for SystemMetrics module
 module SystemMetrics

--- a/files/json2timeseriesdb
+++ b/files/json2timeseriesdb
@@ -1,5 +1,9 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
+# Keep these two scripts in sync.
+# puppetlabs-puppet-metrics-viewer/json2graphite.rb
+# puppetlabs-puppet_metrics_collector/files/json2timeseriesdb
+
 require 'json'
 require 'time'
 require 'optparse'
@@ -16,7 +20,6 @@ class NetworkOutput
 
   def open
     return if @output
-
     @output = case @url.scheme
               when 'tcp'
                 TCPSocket.new(@url.host, @url.port)
@@ -24,7 +27,6 @@ class NetworkOutput
                 http = Net::HTTP.new(@url.hostname, @url.port)
                 http.keep_alive_timeout = 20
                 http.start
-
                 http
               end
   end
@@ -36,17 +38,17 @@ class NetworkOutput
         @output.write(str)
       rescue Errno::EPIPE, Errno::EHOSTUNREACH, Errno::ECONNREFUSED
         close
-        STDERR.puts "WARNING: write to #{@host} failed; sleeping for #{timeout} seconds and retrying..."
+        STDERR.puts "WARNING: Write to #{@host} failed. Sleeping for #{timeout} seconds and retrying ..."
         sleep timeout
         open
+        # Recursive call of this method!
         write(str, timeout * 2)
       end
     when 'http'
       request = Net::HTTP::Post.new(@url)
       request['Connection'] = 'keep-alive'
       response = @output.request(request, str)
-
-      STDERR.puts "POST: #{@url} #{response.code}"
+      STDOUT.puts "POST: #{@url} #{response.code}"
     end
   end
 
@@ -64,7 +66,6 @@ end
 
 def parse_file(filename)
   data = JSON.parse(File.read(filename))
-
   parse_input(data)
 end
 
@@ -75,10 +76,9 @@ def parse_input( data )
     parent_key = nil
   else
     timestamp = get_timestamp(filename)
-    # The only data supported in the older log tool comes from puppetserver.
+    # The only data supported in older versions of the log tool comes from puppetserver.
     parent_key = 'servers.' + get_hoststr(filename) + '.puppetserver'
   end
-
   case $options[:output_format]
   when 'influxdb'
     influx_metrics(data, timestamp, parent_key).join("\n")
@@ -90,8 +90,8 @@ def parse_input( data )
 end
 
 def get_timestamp(str)
-  # Example filename: nzxppc5047.nndc.kp.org-11_29_16_13:00.json
-  timestr = str.match(/(\d\d)_(\d\d)_(\d\d)_(\d\d:\d\d)\.json$/) || raise("Unable to parse timestame from #{str}") # rubocop:disable GetText/DecorateFunctionMessage
+  # Example filename: server.group.example.com-05_08_06_12:30.json
+  timestr = str.match(/(\d\d)_(\d\d)_(\d\d)_(\d\d:\d\d)\.json$/) || raise("Unable to parse timestamp from #{str}") # rubocop:disable GetText/DecorateFunctionMessage
   yyyy = timestr[3].sub(/.*_(\d\d)$/, '20\1')
   mm = timestr[1]
   dd = timestr[2]
@@ -99,8 +99,11 @@ def get_timestamp(str)
   Time.parse("#{yyyy}-#{mm}-#{dd} #{hhmm}")
 end
 
+# Patching via patch_files.rb appears to be orphaned by:
+# https://github.com/puppetlabs/puppet-metrics-viewer/pull/1
+
 def get_hoststr(str)
-  # Example filename: patched.nzxppc5047.nndc.kp.org-11_29_16_13:00.json
+  # Example filename: patched.group.example.com-05_08_06_12:30.json
   str.match(/(patched\.)?([^\/]*)-(\d\d_){3}\d\d:\d\d\.json$/)[2].gsub('.', '-')
 end
 
@@ -113,9 +116,9 @@ def array_cipher
     'http-metrics' => {
       'pkey' => 'route-id',
       'keys' => {
-        'puppet-v3-catalog-/*/' => 'catalog',
-        'puppet-v3-node-/*/'    => 'node',
-        'puppet-v3-report-/*/'  => 'report',
+        'puppet-v3-catalog-/*/'        => 'catalog',
+        'puppet-v3-node-/*/'           => 'node',
+        'puppet-v3-report-/*/'         => 'report',
         'puppet-v3-file_metadata-/*/'  => 'file-metadata',
         'puppet-v3-file_metadatas-/*/' => 'file-metadatas'
       }
@@ -123,12 +126,20 @@ def array_cipher
     'function-metrics' => {
       'pkey' => 'function',
       'keys' => :all
-    }
+    },
+    'catalog-metrics' => {
+      'pkey' => 'metric',
+      'keys' => :all
+    },
+    'resource-metrics' => {
+      'pkey' => 'resource',
+      'keys' => :all
+    },
   }
 end
 
 def error_name(str)
-  if str["mbean"]
+  if str['mbean']
     str[/'[^']+'([^']+)'/,1]
   else
     str
@@ -140,10 +151,12 @@ def return_tag(a, n)
     return a[n]
   else
     if n > -1
-      return_tag(a, n-1)
-    else return "none"
+      # Recursive call of this method!
+      return_tag(a, n - 1)
+    else
+      return 'none'
+    end
   end
-end
 end
 
 def metrics(data, timestamp, parent_key = nil)
@@ -157,7 +170,7 @@ def metrics(data, timestamp, parent_key = nil)
       if cipher
         value.map do |elem|
           pkey_value = elem.delete(cipher['pkey'])
-          elem.map do |k,v|
+          elem.map do |k, v|
             if cipher['keys'] == :all || subkey = cipher['keys'][pkey_value]
               subkey ||= pkey_value
               "#{current_key}.#{safe_name(subkey)}.#{safe_name(k)} #{v} #{timestamp.to_i}"
@@ -181,51 +194,65 @@ def metrics(data, timestamp, parent_key = nil)
 end
 
 def remove_trailing_comma(str)
-    str.nil? ? nil : str.chomp(",")
+  str.nil? ? nil : str.chomp(',')
 end
 
 def influx_tag_parser(tag)
-  delete_set = ["status", "metrics", "routes", "status-service", "experimental", "app", "max", "min", "used", "init", "committed", "aggregate", "mean", "std-dev", "count", "total", "1", "5", "15"]
+  delete_set = ['status', 'metrics', 'routes', 'status-service', 'experimental', 'app', 'max', 'min', 'used', 'init', 'committed', 'aggregate', 'mean', 'std-dev', 'count', 'total', '1', '5', '15']
   tag = tag - delete_set
   tag_set = nil
 
-  if tag.include? "servers"
-    n = tag.index "servers"
+  if tag.include? 'servers'
+    n = tag.index 'servers'
     server_name = $options[:server_tag] || tag[n.to_i + 1]
     tag_set = "server=#{server_name},"
-    tag.delete_at(tag.index("servers")+1)
-    tag.delete("servers")
+    tag.delete_at(tag.index('servers') + 1)
+    tag.delete('servers')
   end
 
-  if tag.include? "orchestrator"
+  if tag.include? 'orchestrator'
     tag_set = "#{tag_set}service=orchestrator,"
-    tag.delete("orchestrator")
+    tag.delete('orchestrator')
   end
 
-  if tag.include? "puppet_server"
+  if tag.include? 'puppet_server'
     tag_set = "#{tag_set}service=puppet_server,"
-    tag.delete("puppet_server")
+    tag.delete('puppet_server')
   end
 
-  if tag.include? "puppetdb"
+  if tag.include? 'puppetdb'
     tag_set = "#{tag_set}service=puppetdb,"
-    tag.delete("puppetdb")
+    tag.delete('puppetdb')
   end
 
-  if tag.include? "gc-stats"
-    n = tag.index "gc-stats"
+  if tag.include? 'gc-stats'
+    n = tag.index 'gc-stats'
     gcstats_name = tag[n.to_i + 1]
     tag_set = "#{tag_set}gc-stats=#{gcstats_name},"
-    tag.delete_at(tag.index("gc-stats")+1)
-    tag.delete("gc-stats")
+    tag.delete_at(tag.index('gc-stats') + 1)
+    tag.delete('gc-stats')
   end
 
-  if tag.include? "broker-service"
-    n = tag.index "broker-service"
+  if tag.include? 'broker-service'
+    n = tag.index 'broker-service'
     brokerservice_name = tag[n.to_i + 1]
     tag_set = "#{tag_set}broker-service_name=#{brokerservice_name},"
-    tag.delete_at(tag.index("broker-service")+1)
-    tag.delete("broker-service")
+    tag.delete_at(tag.index('broker-service') + 1)
+    tag.delete('broker-service')
+  end
+
+  if tag.include?('Queue')
+    n = tag.index('Queue')
+    amq_destination_name = tag[n + 1]
+    tag_set = "#{tag_set}amq-destination-type=Queue,amq-destination-name=#{amq_destination_name}"
+    tag.slice!(n, 2)
+  end
+
+  if tag.include?('Topic')
+    n = tag.index('Topic')
+    amq_destination_name = tag[n + 1]
+    tag_set = "#{tag_set}amq-destination-type=Topic,amq-destination-name=#{amq_destination_name}"
+    tag.slice!(n, 2)
   end
 
   if tag.length > 1
@@ -238,7 +265,6 @@ def influx_tag_parser(tag)
 
   tag_set = remove_trailing_comma(tag_set)
   return tag_set
-
 end
 
 def influx_metrics(data, timestamp, parent_key = nil)
@@ -248,9 +274,9 @@ def influx_metrics(data, timestamp, parent_key = nil)
     when Hash
       influx_metrics(value, timestamp, current_key)
     when Numeric
-      temp_key = current_key.split(".")
+      temp_key = current_key.split('.')
       field_key = return_tag(temp_key, temp_key.length)
-      if field_key.eql? "none"
+      if field_key.eql? 'none'
         break
       end
       field_value = value
@@ -260,32 +286,31 @@ def influx_metrics(data, timestamp, parent_key = nil)
       # Puppet Profiler metric.
       pp_metric = case current_key
                   when /resource-metrics\Z/
-                    "resource"
+                    'resource'
                   when /function-metrics\Z/
-                    "function"
-                  when /catalog-metrics\Z/
-                    "metric"
+                    'function'
+                  when /catalog-metrics\Z/, /puppetdb-metrics\Z/
+                    'metric'
                   when /http-metrics\Z/
-                    "route-id"
+                    'route-id'
+                  when /borrowed-instances\Z/
+                    longest_borrow = value.map {|h| h['duration-millis']}.sort.last
+                    tag_set = influx_tag_parser(current_key.split('.'))
+                    next "#{tag_set} longest-borrow=#{longest_borrow} #{timestamp.to_i}" unless longest_borrow.nil?
                   else
                     # Skip all other array valued metrics.
                     next
                   end
-
-      temp_key = current_key.split(".")
+      temp_key = current_key.split('.')
       tag_set = influx_tag_parser(temp_key)
-
       value.map do |metrics|
         working_set = metrics.dup
         entry_name = working_set.delete(pp_metric)
         next if entry_name.nil?
-
         # Strip characters reserved by InfluxDB.
         entry_name.gsub(/\s,=/, '')
         leader = "#{tag_set},name=#{entry_name}"
-
-        measurements = working_set.map {|k,v| [k,v].join("=")}.join(',')
-
+        measurements = working_set.map {|k,v| [k,v].join('=')}.join(',')
         "#{leader} #{measurements} #{timestamp.to_i}"
       end
     else
@@ -294,36 +319,39 @@ def influx_metrics(data, timestamp, parent_key = nil)
   end.flatten.compact
 end
 
+# Command line options.
+
 $options = {}
 OptionParser.new do |opt|
-  opt.on('--pattern PATTERN') { |o| $options[:pattern] = o }
-  opt.on('--netcat HOST') { |o| $options[:host] = o }
-  opt.on('--port PORT')   { |p| $options[:port] = p }
-  opt.on('--convert-to FORMAT') { |o| $options[:output_format] = o }
-  opt.on('--server-tag SERVER_NAME') { |o| $options[:server_tag] = o }
-
-  # InfluxDB options
-  opt.on('--influx-db DATABASE_NAME') {|o| $options[:influx_db] = o }
+  opt.on('--convert-to FORMAT')       { |o| $options[:output_format] = o }
+  opt.on('--influx-db DATABASE_NAME') { |o| $options[:influx_db] = o }
+  opt.on('--netcat HOST')             { |o| $options[:host] = o }
+  opt.on('--pattern PATTERN')         { |o| $options[:pattern] = o }
+  opt.on('--port PORT')               { |o| $options[:port] = o }
+  opt.on('--server-tag SERVER_NAME')  { |o| $options[:server_tag] = o }
 end.parse!
 
 if $options[:host]
   url = case $options[:output_format]
         when 'influxdb'
-          raise ArgumentError, "--influx-db must be passsed along with --netcat" unless $options[:influx_db] # rubocop:disable GetText/DecorateFunctionMessage
-          port = $options[:port] || "8086"
+          raise ArgumentError, '--influx-db must be passsed along with --netcat' unless $options[:influx_db] # rubocop:disable GetText/DecorateFunctionMessage
+          port = $options[:port] || '8086'
           "http://#{$options[:host]}:#{port}/write?db=#{$options[:influx_db]}&precision=s"
         else
-          port = $options[:port] || "2003"
+          port = $options[:port] || '2003'
           "tcp://#{$options[:host]}:#{port}"
         end
-
   $net_output = NetworkOutput.new(url)
 end
+
+# Collect JSON files to process from '--pattern'.
 
 data_files = []
 data_files += Dir.glob($options[:pattern]) if $options[:pattern]
 
-#http://ruby-doc.org/core-1.9.3/ARGF.html#method-i-filename
+# Collect JSON files to process from ARGF.
+# http://ruby-doc.org/core-1.9.3/ARGF.html#method-i-filename
+
 while ARGF.filename != '-'
   filename = ARGF.filename
   data_files += [filename]
@@ -331,10 +359,11 @@ while ARGF.filename != '-'
   break if filename == ARGF.filename
 end
 
+# Process collected JSON files.
+
 data_files.each do |filename|
   begin
     converted_data = parse_file(filename)
-
     if $options[:host]
       $net_output.write(converted_data)
     else
@@ -345,14 +374,15 @@ data_files.each do |filename|
   end
 end
 
+# Process JSON data from STDIN.
+
 if ARGF.filename == '-'
   begin
     converted_data = parse_input( JSON.parse(ARGF.read) )
-
     if $options[:host]
       $net_output.write(converted_data)
     else
-      STDOUT.write(converted_data)
+      STDOUT.puts(converted_data)
     end
   rescue => e
     STDERR.puts "ERROR: During read from STDIN: #{e.message}"


### PR DESCRIPTION
The process data gathering greps process names for the ones we wanted to track... then passes the list to sar to track.  If a process passed to sar exists when sar starts, but exits before sar gathers the first round of data, then sar will crash while printing the average summaries.  Thus we lose data.

Also, if the process exited before sar ran, there would be no data and some of the generate_system_metrics code would crash expecting to find that process in the sar results.

Fine tuned the process grep to avoid matching processes we don't care about.
Put a catch to not crash if one of the processes we expect doesn't have any data.