### PR TITLE
(PIE-178) Print metrics as line-delimited JSON

### DIFF
--- a/files/amq_metrics
+++ b/files/amq_metrics
@@ -99,7 +99,7 @@ HOSTS.each do |host|
     dataset['servers'][hostkey][METRICS_TYPE]['api-query-start'] = timestamp.utc.iso8601
     dataset['servers'][hostkey][METRICS_TYPE]['api-query-duration'] = Time.now - timestamp
 
-    json_dataset = JSON.pretty_generate(dataset)
+    json_dataset = JSON.generate(dataset)
 
     unless OUTPUT_DIR.nil? then
       Dir.chdir(OUTPUT_DIR) do
@@ -110,7 +110,10 @@ HOSTS.each do |host|
       end
     end
     if options[:print] != false then
-      STDOUT.write(json_dataset)
+      # Use puts so that data gatherd from each host is written to stdout
+      # with a newline separator. This enables parsing of multiple datasets
+      # as the output stream is in line-delimited JSON form.
+      STDOUT.puts(json_dataset)
     end
   rescue Exception => e
     STDERR.puts "Error getting metrics for #{host}: #{e}"

--- a/files/puma_metrics
+++ b/files/puma_metrics
@@ -154,7 +154,10 @@ HOSTS.each do |host|
       end
     end
     if options[:print] != false then
-      STDOUT.write(json_dataset)
+      # Use puts so that data gatherd from each host is written to stdout
+      # with a newline separator. This enables parsing of multiple datasets
+      # as the output stream is in line-delimited JSON form.
+      STDOUT.puts(json_dataset)
     end
   end
 end

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -197,7 +197,10 @@ HOSTS.each do |host|
       end
     end
     if options[:print] != false then
-      STDOUT.write(json_dataset)
+      # Use puts so that data gatherd from each host is written to stdout
+      # with a newline separator. This enables parsing of multiple datasets
+      # as the output stream is in line-delimited JSON form.
+      STDOUT.puts(json_dataset)
     end
   end
 end


### PR DESCRIPTION
This commit updates the scripts that collect metrics from multiple
hosts, amq_metrics, puma_metrics, and tk_metrics, to write each
dataset to STDOUT with a trailing newline. The resulting output
stream is therefore in line-delimited JSON format, which is easy
to parse.

Prior to this commit, datasets from multiple hosts were mashed together
without separators, which was difficult to parse when used as input
for other scripts.