### PR TITLE
Allow for handling multiple hashes with STDIN

### DIFF
--- a/files/json2timeseriesdb
+++ b/files/json2timeseriesdb
@@ -378,9 +378,10 @@ end
 
 if ARGF.filename == '-'
   begin
-    converted_data = parse_input( JSON.parse(ARGF.read) )
+    input = ARGF.read
+    converted_data = input.lines.map { |l| parse_input( JSON.parse(l) )}
     if $options[:host]
-      $net_output.write(converted_data)
+      $net_output.write(converted_data.flatten.join("\n"))
     else
       STDOUT.puts(converted_data)
     end


### PR DESCRIPTION
Prior to this commit, the json2timeseriesdb script would fail with the
STDIN input method. The collection script outputs multiple newline
delimited hashes, which caused the JSON parser to fail. This commit
updates the json2timeseriesdb script to be able to handle this input
format.

This can be tested by configuring the metrics collector to ship metrics to a dashboard with something like the following.

```
  class {'puppet_metrics_collector':
    metrics_server_type => 'influxdb',
    metrics_server_hostname => 'pe-201911-agent.puppetdebug.vlan',
    metrics_server_db_name => 'puppet_metrics',
  }
```

It fixes the issue when there are multiple masters that are bundled into the same output.