### PR TITLE
Better error handling in tidy script

### DIFF
--- a/files/metrics_tidy
+++ b/files/metrics_tidy
@@ -1,5 +1,23 @@
 #!/bin/bash
 
+fail() {
+  # Restore stdout by pointing it to fd 3 and send any errors to it
+  exec >&3
+  cat "$tmp"
+  rm "$tmp"
+
+  exit 1
+}
+
+# Clone, i.e. preserve, original stdout using fd 3.
+exec 3>&1
+# Send stderr and stdout to a temp file
+tmp="$(mktemp)"
+exec &>"$tmp"
+
+# Run the fail() method on error
+trap fail ERR
+
 while [[ $1 ]]; do
   case "$1" in
     '-d'|'--directory')
@@ -11,11 +29,12 @@ while [[ $1 ]]; do
   shift 2
 done
 
-# Arguments and defaults.
+
 
 # Guard against deleting or archiving files outside of a Puppet service metrics directory.
 valid_paths=(puppetserver puppetdb orchestrator ace bolt activemq)
 
+# Arguments and defaults.
 metrics_directory="${metrics_directory:-/opt/puppetlabs/puppet-metrics-collector/puppetserver}"
 retention_days="${retention_days:-90}"
 
@@ -26,12 +45,13 @@ metrics_type="${metrics_directory##*/}"
 paths_regex="$(IFS='|'; echo "${valid_paths[*]}")"
 [[ $metrics_directory =~ ${paths_regex}$ ]] || {
   echo "Error: Invalid metrics directory. Must end in one of: $(echo -n "${valid_paths[@]}")."
-  exit 1
+  fail
 }
 
 # Delete files in a Puppet service metrics directory older than the retention period, in days.
 find "$metrics_directory" -type f -ctime +"$retention_days" -delete
 
 # Compress the remaining files in a Puppet service metrics directory.
+# The return code of a pipeline is the rightmost command, which means we trigger our trap if tar fails
 find "$metrics_directory" -type f -name "*json" | \
-  tar --create --gzip --file "${metrics_directory}/${metrics_type}-$(date +%Y.%m.%d.%H.%M.%S).tar.gz" --files-from - 2>/dev/null
+  tar --create --gzip --file "${metrics_directory}/${metrics_type}-$(date +%Y.%m.%d.%H.%M.%S).tar.gz" --files-from -


### PR DESCRIPTION
In this commit, we create a temp file to hold stdout and stderr.  We set
a trap on error, which will send the temp file to stdout.  This has the
effect of sending the output upon error to mail when run via cron.