### PR TITLE
(PE-28451) switch from the v1 to v2 metrics api

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,22 +177,6 @@ puppetdb/master.example.com/20190404T171001Z.json: "queue_depth": 0,
 puppetdb/master.example.com/20190404T171502Z.json: "queue_depth": 0,
 ```
 
-Example for PE 2016.5 and older:
-
-```bash
-grep Cursor puppetdb/master.example.com/*.json
-
-puppetdb/master.example.com/20190404T171001Z.json: "CursorMemoryUsage": 0,
-puppetdb/master.example.com/20190404T171001Z.json: "CursorFull": false,
-puppetdb/master.example.com/20190404T171001Z.json: "CursorPercentUsage": 0,
-puppetdb/master.example.com/20190404T171502Z.json: "CursorMemoryUsage": 0,
-puppetdb/master.example.com/20190404T171502Z.json: "CursorFull": false,
-puppetdb/master.example.com/20190404T171502Z.json: "CursorPercentUsage": 0,
-puppetdb/master.example.com/20190404T172002Z.json: "CursorMemoryUsage": 0,
-puppetdb/master.example.com/20190404T172002Z.json: "CursorFull": false,
-puppetdb/master.example.com/20190404T172002Z.json: "CursorPercentUsage": 0,
-```
-
 ### Sharing Metrics Data
 
 When working with Support, you may be asked for an archive of collected metrics data.
@@ -368,17 +352,23 @@ Classify each PE Infrastructure Host with this module, specifying the following 
 When classifying a Compile Master, specify these additional parameters:
 
 ```puppet
+class { 'puppet_metrics_collector':
+  puppetserver_hosts          => ['127.0.0.1'],
   puppetdb_metrics_ensure     => absent,
   orchestrator_metrics_ensure => absent,
   ace_metrics_ensure          => absent,
   bolt_metrics_ensure         => absent,
+}
 ```
 
 When classifying a PuppetDB Host, specify these additional parameters:
 
 ```puppet
+class { 'puppet_metrics_collector':
+  puppetdb_hosts              => ['127.0.0.1'],
   puppetserver_metrics_ensure => absent,
   orchestrator_metrics_ensure => absent,
   ace_metrics_ensure          => absent,
   bolt_metrics_ensure         => absent,
+}
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Table of Contents
 This module collects metrics provided by the status endpoints of Puppet Enterprise services.
 The metrics can be used to identify performance issues that may be addressed by performance tuning.
 
+> In PE 2018.1.13 and newer and PE 2019.4 and newer, the `/metrics/v1` endpoints are disabled by default and access to the `/metrics/v2` endpoints are restricted to localhost ... in response to CVE-2020-7943. 
+This module requires access those endpoints to collect additional metrics from PuppetDB, and those metrics will not be collected from remote PuppetDB hosts until these restricted are resolved.
+Refer to [Configuration for Distributed Metrics Collection](#Configuration-for-distributed-metrics-collection) for a workaround. 
+
 
 ## Setup
 

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -26,7 +26,7 @@ HOSTS.each do |host|
     dataset['servers'][hostkey][METRICS_TYPE] = status_output
 
     unless ADDITIONAL_METRICS.empty? then
-      metrics_array = retrieve_additional_metrics(host, PORT, USE_SSL, PE_VERSION, ADDITIONAL_METRICS)
+      metrics_array = retrieve_additional_metrics(host, PORT, USE_SSL, METRICS_TYPE, ADDITIONAL_METRICS)
       metrics_array.each do |metric_hash|
         metric_name = metric_hash['name']
         metric_data = metric_hash['data']

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -48,6 +48,7 @@ define puppet_metrics_collector::pe_metric (
   $metric_script_file_path = "${puppet_metrics_collector::scripts_dir}/${metric_script_file}"
   $conversion_script_file_path = "${puppet_metrics_collector::scripts_dir}/json2timeseriesdb"
 
+  # lint:ignore:140chars
   if empty($override_metrics_command) {
     $base_metrics_command = "${metric_script_file_path} --metrics_type ${metrics_type} --output_dir ${metrics_output_dir}"
 
@@ -79,10 +80,10 @@ define puppet_metrics_collector::pe_metric (
     } else {
       $metrics_command = "${base_metrics_command} --no-print"
     }
-
   } else {
     $metrics_command = $override_metrics_command
   }
+  # lint:endignore
 
   cron { "${metrics_type}_metrics_collection" :
     ensure  => $metric_ensure,

--- a/manifests/service/activemq.pp
+++ b/manifests/service/activemq.pp
@@ -12,6 +12,7 @@ class puppet_metrics_collector::service::activemq (
   Optional[Integer]       $metrics_server_port      = $puppet_metrics_collector::metrics_server_port,
   Optional[String]        $metrics_server_db_name   = $puppet_metrics_collector::metrics_server_db_name,
 ) {
+  # lint:ignore:140chars
   $additional_metrics = [
     {
       'type'      => 'read',
@@ -49,6 +50,7 @@ class puppet_metrics_collector::service::activemq (
       'attribute' => 'AverageBlockedTime,AverageEnqueueTime,AverageMessageSize,ConsumerCount,DequeueCount,DispatchCount,EnqueueCount,ExpiredCount,ForwardCount,InFlightCount,ProducerCount,QueueSize',
     },
   ]
+  # lint:endignore
 
   file { "${puppet_metrics_collector::scripts_dir}/amq_metrics" :
     ensure => $metrics_ensure,

--- a/manifests/service/activemq.pp
+++ b/manifests/service/activemq.pp
@@ -12,44 +12,6 @@ class puppet_metrics_collector::service::activemq (
   Optional[Integer]       $metrics_server_port      = $puppet_metrics_collector::metrics_server_port,
   Optional[String]        $metrics_server_db_name   = $puppet_metrics_collector::metrics_server_db_name,
 ) {
-  $additional_metrics = [
-    {
-      'type'      => 'read',
-      'mbean'     => 'java.lang:type=Memory',
-      'attribute' => 'HeapMemoryUsage,NonHeapMemoryUsage'
-    },
-    {
-      'type'      => 'read',
-      'mbean'     => 'java.lang:name=*,type=GarbageCollector',
-      'attribute' => 'CollectionCount'
-    },
-    {
-      'type'      => 'read',
-      'mbean'     => 'java.lang:type=Runtime',
-      'attribute' => 'Uptime'
-    },
-    {
-      'type'      => 'read',
-      'mbean'     => 'java.lang:type=OperatingSystem',
-      'attribute' => 'OpenFileDescriptorCount,MaxFileDescriptorCount'
-    },
-    {
-      'type'      => 'read',
-      'mbean'     => 'org.apache.activemq:brokerName=*,type=Broker',
-      'attribute' => 'MemoryLimit,MemoryPercentUsage,CurrentConnectionsCount'
-    },
-    {
-      'type'      => 'read',
-      'mbean'     => 'org.apache.activemq:type=Broker,brokerName=*,destinationType=Queue,destinationName=mcollective.*',
-      'attribute' => 'AverageBlockedTime,AverageEnqueueTime,AverageMessageSize,ConsumerCount,DequeueCount,DispatchCount,EnqueueCount,ExpiredCount,ForwardCount,InFlightCount,ProducerCount,QueueSize',
-    },
-    {
-      'type'      => 'read',
-      'mbean'     => 'org.apache.activemq:type=Broker,brokerName=*,destinationType=Topic,destinationName=mcollective.*.agent',
-      'attribute' => 'AverageBlockedTime,AverageEnqueueTime,AverageMessageSize,ConsumerCount,DequeueCount,DispatchCount,EnqueueCount,ExpiredCount,ForwardCount,InFlightCount,ProducerCount,QueueSize',
-    },
-  ]
-
   file { "${puppet_metrics_collector::scripts_dir}/amq_metrics" :
     ensure => $metrics_ensure,
     mode   => '0755',
@@ -65,7 +27,7 @@ class puppet_metrics_collector::service::activemq (
     metric_script_file       => 'amq_metrics',
     override_metrics_command => $override_metrics_command,
     excludes                 => $excludes,
-    additional_metrics       => $additional_metrics,
+    additional_metrics       => [],
     metrics_server_type      => $metrics_server_type,
     metrics_server_hostname  => $metrics_server_hostname,
     metrics_server_port      => $metrics_server_port,

--- a/manifests/service/activemq.pp
+++ b/manifests/service/activemq.pp
@@ -12,6 +12,44 @@ class puppet_metrics_collector::service::activemq (
   Optional[Integer]       $metrics_server_port      = $puppet_metrics_collector::metrics_server_port,
   Optional[String]        $metrics_server_db_name   = $puppet_metrics_collector::metrics_server_db_name,
 ) {
+  $additional_metrics = [
+    {
+      'type'      => 'read',
+      'mbean'     => 'java.lang:type=Memory',
+      'attribute' => 'HeapMemoryUsage,NonHeapMemoryUsage'
+    },
+    {
+      'type'      => 'read',
+      'mbean'     => 'java.lang:name=*,type=GarbageCollector',
+      'attribute' => 'CollectionCount'
+    },
+    {
+      'type'      => 'read',
+      'mbean'     => 'java.lang:type=Runtime',
+      'attribute' => 'Uptime'
+    },
+    {
+      'type'      => 'read',
+      'mbean'     => 'java.lang:type=OperatingSystem',
+      'attribute' => 'OpenFileDescriptorCount,MaxFileDescriptorCount'
+    },
+    {
+      'type'      => 'read',
+      'mbean'     => 'org.apache.activemq:brokerName=*,type=Broker',
+      'attribute' => 'MemoryLimit,MemoryPercentUsage,CurrentConnectionsCount'
+    },
+    {
+      'type'      => 'read',
+      'mbean'     => 'org.apache.activemq:type=Broker,brokerName=*,destinationType=Queue,destinationName=mcollective.*',
+      'attribute' => 'AverageBlockedTime,AverageEnqueueTime,AverageMessageSize,ConsumerCount,DequeueCount,DispatchCount,EnqueueCount,ExpiredCount,ForwardCount,InFlightCount,ProducerCount,QueueSize',
+    },
+    {
+      'type'      => 'read',
+      'mbean'     => 'org.apache.activemq:type=Broker,brokerName=*,destinationType=Topic,destinationName=mcollective.*.agent',
+      'attribute' => 'AverageBlockedTime,AverageEnqueueTime,AverageMessageSize,ConsumerCount,DequeueCount,DispatchCount,EnqueueCount,ExpiredCount,ForwardCount,InFlightCount,ProducerCount,QueueSize',
+    },
+  ]
+
   file { "${puppet_metrics_collector::scripts_dir}/amq_metrics" :
     ensure => $metrics_ensure,
     mode   => '0755',
@@ -27,7 +65,7 @@ class puppet_metrics_collector::service::activemq (
     metric_script_file       => 'amq_metrics',
     override_metrics_command => $override_metrics_command,
     excludes                 => $excludes,
-    additional_metrics       => [],
+    additional_metrics       => $additional_metrics,
     metrics_server_type      => $metrics_server_type,
     metrics_server_hostname  => $metrics_server_hostname,
     metrics_server_port      => $metrics_server_port,

--- a/manifests/service/puppetdb.pp
+++ b/manifests/service/puppetdb.pp
@@ -28,11 +28,11 @@ class puppet_metrics_collector::service::puppetdb (
       'name'  => 'global_fatal',
       'mbean' => 'puppetlabs.puppetdb.mq:name=global.fatal'
     },
-    #{
-    #  'type'  => 'read',
-    #  'name'  => 'global_generate-retry-message-time',
-    #  'mbean' => 'puppetlabs.puppetdb.mq:name=global.generate-retry-message-time'
-    #},
+    { # This counter doesn't exist until a failure occurs.
+      'type'  => 'read',
+      'name'  => 'global_generate-retry-message-time',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.generate-retry-message-time'
+    },
     {
       'type'  => 'read',
       'name'  => 'global_message-persistence-time',
@@ -48,11 +48,11 @@ class puppet_metrics_collector::service::puppetdb (
       'name'  => 'global_retry-counts',
       'mbean' => 'puppetlabs.puppetdb.mq:name=global.retry-counts'
     },
-    #{
-    #  'type'  => 'read',
-    #  'name'  => 'global_retry-persistence-time',
-    #  'mbean' => 'puppetlabs.puppetdb.mq:name=global.retry-persistence-time'
-    #},
+    { # This counter doesn't exist until a failure occurs.
+      'type'  => 'read',
+      'name'  => 'global_retry-persistence-time',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.retry-persistence-time'
+    },
     {
       'type'  => 'read',
       'name'  => 'global_seen',
@@ -178,42 +178,38 @@ class puppet_metrics_collector::service::puppetdb (
     }
   ]
 
-  # Retaining for future reference.
-  $numbers = $::pe_server_version ? {
-    /^2016\.[45]\./ => {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
-    default         => {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
-  }
+  $version = {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
 
   $version_specific_metrics = [
     {
       'type'  => 'read',
       'name'  => 'mq_replace_catalog_retried',
-      'mbean' => "puppetlabs.puppetdb.mq:name=replace catalog.${numbers['catalogs']}.retried"
+      'mbean' => "puppetlabs.puppetdb.mq:name=replace catalog.${version['catalogs']}.retried"
     },
     {
       'type'  => 'read',
       'name'  => 'mq_replace_catalog_retry-counts',
-      'mbean' => "puppetlabs.puppetdb.mq:name=replace catalog.${numbers['catalogs']}.retry-counts"
+      'mbean' => "puppetlabs.puppetdb.mq:name=replace catalog.${version['catalogs']}.retry-counts"
     },
     {
       'type'  => 'read',
       'name'  => 'mq_replace_facts_retried',
-      'mbean' => "puppetlabs.puppetdb.mq:name=replace facts.${numbers['facts']}.retried"
+      'mbean' => "puppetlabs.puppetdb.mq:name=replace facts.${version['facts']}.retried"
     },
     {
       'type'  => 'read',
       'name'  => 'mq_replace_facts_retry-counts',
-      'mbean' => "puppetlabs.puppetdb.mq:name=replace facts.${numbers['facts']}.retry-counts"
+      'mbean' => "puppetlabs.puppetdb.mq:name=replace facts.${version['facts']}.retry-counts"
     },
     {
       'type'  => 'read',
       'name'  => 'mq_store_report_retried',
-      'mbean' => "puppetlabs.puppetdb.mq:name=store report.${numbers['reports']}.retried"
+      'mbean' => "puppetlabs.puppetdb.mq:name=store report.${version['reports']}.retried"
     },
     {
       'type'  => 'read',
       'name'  => 'mq_store_reports_retry-counts',
-      'mbean' => "puppetlabs.puppetdb.mq:name=store report.${numbers['reports']}.retry-counts"
+      'mbean' => "puppetlabs.puppetdb.mq:name=store report.${version['reports']}.retry-counts"
     }
   ]
 
@@ -291,11 +287,11 @@ class puppet_metrics_collector::service::puppetdb (
       'name'  => 'ha_seconds-since-last-successful-sync',
       'mbean' => 'puppetlabs.puppetdb.ha:name=seconds-since-last-successful-sync'
     },
-    #{
-    #  'type'  => 'read',
-    #  'name'  => 'ha_failed-request-counter',
-    #  'mbean' => 'puppetlabs.puppetdb.ha:name=failed-request-counter'
-    #},
+    { # This counter doesn't exist until a failure occurs.
+      'type'  => 'read',
+      'name'  => 'ha_failed-request-counter',
+      'mbean' => 'puppetlabs.puppetdb.ha:name=failed-request-counter'
+    },
     {
       'type'  => 'read',
       'name'  => 'ha_sync-duration',

--- a/manifests/service/puppetdb.pp
+++ b/manifests/service/puppetdb.pp
@@ -178,7 +178,7 @@ class puppet_metrics_collector::service::puppetdb (
     }
   ]
 
-  $version = {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
+  $version = {'catalogs' => 9, 'facts' => 5, 'reports' => 8}
 
   $version_specific_metrics = [
     {

--- a/manifests/service/puppetdb.pp
+++ b/manifests/service/puppetdb.pp
@@ -28,11 +28,11 @@ class puppet_metrics_collector::service::puppetdb (
       'name'  => 'global_fatal',
       'mbean' => 'puppetlabs.puppetdb.mq:name=global.fatal'
     },
-    {
-      'type'  => 'read',
-      'name'  => 'global_generate-retry-message-time',
-      'mbean' => 'puppetlabs.puppetdb.mq:name=global.generate-retry-message-time'
-    },
+    #{
+    #  'type'  => 'read',
+    #  'name'  => 'global_generate-retry-message-time',
+    #  'mbean' => 'puppetlabs.puppetdb.mq:name=global.generate-retry-message-time'
+    #},
     {
       'type'  => 'read',
       'name'  => 'global_message-persistence-time',
@@ -48,11 +48,11 @@ class puppet_metrics_collector::service::puppetdb (
       'name'  => 'global_retry-counts',
       'mbean' => 'puppetlabs.puppetdb.mq:name=global.retry-counts'
     },
-    {
-      'type'  => 'read',
-      'name'  => 'global_retry-persistence-time',
-      'mbean' => 'puppetlabs.puppetdb.mq:name=global.retry-persistence-time'
-    },
+    #{
+    #  'type'  => 'read',
+    #  'name'  => 'global_retry-persistence-time',
+    #  'mbean' => 'puppetlabs.puppetdb.mq:name=global.retry-persistence-time'
+    #},
     {
       'type'  => 'read',
       'name'  => 'global_seen',
@@ -291,11 +291,11 @@ class puppet_metrics_collector::service::puppetdb (
       'name'  => 'ha_seconds-since-last-successful-sync',
       'mbean' => 'puppetlabs.puppetdb.ha:name=seconds-since-last-successful-sync'
     },
-    {
-      'type'  => 'read',
-      'name'  => 'ha_failed-request-counter',
-      'mbean' => 'puppetlabs.puppetdb.ha:name=failed-request-counter'
-    },
+    #{
+    #  'type'  => 'read',
+    #  'name'  => 'ha_failed-request-counter',
+    #  'mbean' => 'puppetlabs.puppetdb.ha:name=failed-request-counter'
+    #},
     {
       'type'  => 'read',
       'name'  => 'ha_sync-duration',

--- a/manifests/service/puppetdb.pp
+++ b/manifests/service/puppetdb.pp
@@ -12,166 +12,327 @@ class puppet_metrics_collector::service::puppetdb (
   Optional[Integer]       $metrics_server_port      = $puppet_metrics_collector::metrics_server_port,
   Optional[String]        $metrics_server_db_name   = $puppet_metrics_collector::metrics_server_db_name,
   ) {
-  $activemq_metrics = [
-    { 'name' => 'amq_metrics',
-      'url'  => 'org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=puppetlabs.puppetdb.commands' }
-  ]
-
   $base_metrics = [
-    { 'name' => 'global_command-parse-time',
-      'url'  => 'puppetlabs.puppetdb.mq:name=global.command-parse-time' },
-    { 'name' => 'global_discarded',
-      'url'  => 'puppetlabs.puppetdb.mq:name=global.discarded' },
-    { 'name' => 'global_fatal',
-      'url'  => 'puppetlabs.puppetdb.mq:name=global.fatal' },
-    { 'name' => 'global_generate-retry-message-time',
-      'url'  => 'puppetlabs.puppetdb.mq:name=global.generate-retry-message-time' },
-    { 'name' => 'global_message-persistence-time',
-      'url'  => 'puppetlabs.puppetdb.mq:name=global.message-persistence-time' },
-    { 'name' => 'global_retried',
-      'url'  => 'puppetlabs.puppetdb.mq:name=global.retried' },
-    { 'name' => 'global_retry-counts',
-      'url'  => 'puppetlabs.puppetdb.mq:name=global.retry-counts' },
-    { 'name' => 'global_retry-persistence-time',
-      'url'  => 'puppetlabs.puppetdb.mq:name=global.retry-persistence-time' },
-    { 'name' => 'global_seen',
-      'url'  => 'puppetlabs.puppetdb.mq:name=global.seen' },
-    { 'name' => 'global_processed',
-      'url'  => 'puppetlabs.puppetdb.mq:name=global.processed' },
-    { 'name' => 'global_processing-time',
-      'url'  => 'puppetlabs.puppetdb.mq:name=global.processing-time' },
+    {
+      'type'  => 'read',
+      'name'  => 'global_command-parse-time',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.command-parse-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'global_discarded',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.discarded'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'global_fatal',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.fatal'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'global_generate-retry-message-time',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.generate-retry-message-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'global_message-persistence-time',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.message-persistence-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'global_retried',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.retried'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'global_retry-counts',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.retry-counts'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'global_retry-persistence-time',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.retry-persistence-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'global_seen',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.seen'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'global_processed',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.processed'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'global_processing-time',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.processing-time'
+    }
   ]
 
   $storage_metrics = [
-    { 'name' => 'storage_add-edges',
-      'url'  => 'puppetlabs.puppetdb.storage:name=add-edges' },
-    { 'name' => 'storage_add-resources',
-      'url'  => 'puppetlabs.puppetdb.storage:name=add-resources' },
-    { 'name' => 'storage_catalog-hash',
-      'url'  => 'puppetlabs.puppetdb.storage:name=catalog-hash' },
-    { 'name' => 'storage_catalog-hash-match-time',
-      'url'  => 'puppetlabs.puppetdb.storage:name=catalog-hash-match-time' },
-    { 'name' => 'storage_catalog-hash-miss-time',
-      'url'  => 'puppetlabs.puppetdb.storage:name=catalog-hash-miss-time' },
-    { 'name' => 'storage_gc-catalogs-time',
-      'url'  => 'puppetlabs.puppetdb.storage:name=gc-catalogs-time' },
-    { 'name' => 'storage_gc-environments-time',
-      'url'  => 'puppetlabs.puppetdb.storage:name=gc-environments-time' },
-    { 'name' => 'storage_gc-fact-paths',
-      'url'  => 'puppetlabs.puppetdb.storage:name=gc-fact-paths' },
-    { 'name' => 'storage_gc-params-time',
-      'url'  => 'puppetlabs.puppetdb.storage:name=gc-params-time' },
-    { 'name' => 'storage_gc-report-statuses',
-      'url'  => 'puppetlabs.puppetdb.storage:name=gc-report-statuses' },
-    { 'name' => 'storage_gc-time',
-      'url'  => 'puppetlabs.puppetdb.storage:name=gc-time' },
-    { 'name' => 'storage_new-catalog-time',
-      'url'  => 'puppetlabs.puppetdb.storage:name=new-catalog-time' },
-    { 'name' => 'storage_new-catalogs',
-      'url'  => 'puppetlabs.puppetdb.storage:name=new-catalogs' },
-    { 'name' => 'storage_replace-catalog-time',
-      'url'  => 'puppetlabs.puppetdb.storage:name=replace-catalog-time' },
-    { 'name' => 'storage_replace-facts-time',
-      'url'  => 'puppetlabs.puppetdb.storage:name=replace-facts-time' },
-    { 'name' => 'storage_resource-hashes',
-      'url'  => 'puppetlabs.puppetdb.storage:name=resource-hashes' },
-    { 'name' => 'storage_store-report-time',
-      'url'  => 'puppetlabs.puppetdb.storage:name=store-report-time' },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_add-edges',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=add-edges'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_add-resources',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=add-resources'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_catalog-hash',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=catalog-hash'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_catalog-hash-match-time',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=catalog-hash-match-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_catalog-hash-miss-time',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=catalog-hash-miss-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_gc-catalogs-time',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=gc-catalogs-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_gc-environments-time',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=gc-environments-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_gc-fact-paths',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=gc-fact-paths'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_gc-params-time',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=gc-params-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_gc-report-statuses',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=gc-report-statuses'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_gc-time',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=gc-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_new-catalog-time',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=new-catalog-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_new-catalogs',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=new-catalogs'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_replace-catalog-time',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=replace-catalog-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_replace-facts-time',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=replace-facts-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_resource-hashes',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=resource-hashes'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_store-report-time',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=store-report-time'
+    }
   ]
 
   # TODO: Track these on a less frequent cadence because they are slow to run
 
   $storage_metrics_db_queries = [
-    { 'name' => 'storage_catalog-volitilty',
-      'url'  => 'puppetlabs.puppetdb.storage:name=catalog-volitilty' },
-    { 'name' => 'storage_duplicate-catalogs',
-      'url'  => 'puppetlabs.puppetdb.storage:name=duplicate-catalogs' },
-    { 'name' => 'storage_duplicate-pct',
-      'url'  => 'puppetlabs.puppetdb.storage:name=duplicate-pct' },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_catalog-volitilty',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=catalog-volitilty'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_duplicate-catalogs',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=duplicate-catalogs'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'storage_duplicate-pct',
+      'mbean' => 'puppetlabs.puppetdb.storage:name=duplicate-pct'
+    }
   ]
 
+  # Retaining for future reference.
   $numbers = $::pe_server_version ? {
-    /^2015.2/     => {'catalogs' => 6, 'facts' => 4, 'reports' => 6},
-    /^2015.3/     => {'catalogs' => 7, 'facts' => 4, 'reports' => 6},
-    /^2016.(1|2)/ => {'catalogs' => 8, 'facts' => 4, 'reports' => 7},
-    /^2016.(4|5)/ => {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
-    /^2017.(1|2)/ => {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
-    default       => {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
+    /^2016\.[45]\./ => {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
+    default         => {'catalogs' => 9, 'facts' => 5, 'reports' => 8},
   }
 
   $version_specific_metrics = [
-    { 'name' => 'mq_replace_catalog_retried',
-      'url'  => "puppetlabs.puppetdb.mq:name=replace catalog.${numbers['catalogs']}.retried" },
-    { 'name' => 'mq_replace_catalog_retry-counts',
-      'url'  => "puppetlabs.puppetdb.mq:name=replace catalog.${numbers['catalogs']}.retry-counts" },
-    { 'name' => 'mq_replace_facts_retried',
-      'url'  => "puppetlabs.puppetdb.mq:name=replace facts.${numbers['facts']}.retried" },
-    { 'name' => 'mq_replace_facts_retry-counts',
-      'url'  => "puppetlabs.puppetdb.mq:name=replace facts.${numbers['facts']}.retry-counts" },
-    { 'name' => 'mq_store_report_retried',
-      'url'  => "puppetlabs.puppetdb.mq:name=store report.${numbers['reports']}.retried" },
-    { 'name' => 'mq_store_reports_retry-counts',
-      'url'  => "puppetlabs.puppetdb.mq:name=store report.${numbers['reports']}.retry-counts" },
+    {
+      'type'  => 'read',
+      'name'  => 'mq_replace_catalog_retried',
+      'mbean' => "puppetlabs.puppetdb.mq:name=replace catalog.${numbers['catalogs']}.retried"
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'mq_replace_catalog_retry-counts',
+      'mbean' => "puppetlabs.puppetdb.mq:name=replace catalog.${numbers['catalogs']}.retry-counts"
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'mq_replace_facts_retried',
+      'mbean' => "puppetlabs.puppetdb.mq:name=replace facts.${numbers['facts']}.retried"
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'mq_replace_facts_retry-counts',
+      'mbean' => "puppetlabs.puppetdb.mq:name=replace facts.${numbers['facts']}.retry-counts"
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'mq_store_report_retried',
+      'mbean' => "puppetlabs.puppetdb.mq:name=store report.${numbers['reports']}.retried"
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'mq_store_reports_retry-counts',
+      'mbean' => "puppetlabs.puppetdb.mq:name=store report.${numbers['reports']}.retry-counts"
+    }
   ]
 
   $connection_pool_metrics = [
-    { 'name' => 'PDBReadPool_pool_ActiveConnections',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.ActiveConnections' },
-    { 'name' => 'PDBReadPool_pool_IdleConnections',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.IdleConnections' },
-    { 'name' => 'PDBReadPool_pool_PendingConnections',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.PendingConnections' },
-    { 'name' => 'PDBReadPool_pool_TotalConnections',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.TotalConnections' },
-    { 'name' => 'PDBReadPool_pool_Usage',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.Usage' },
-    { 'name' => 'PDBReadPool_pool_Wait',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.Wait' },
-    { 'name' => 'PDBWritePool_pool_ActiveConnections',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.ActiveConnections' },
-    { 'name' => 'PDBWritePool_pool_IdleConnections',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.IdleConnections' },
-    { 'name' => 'PDBWritePool_pool_PendingConnections',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.PendingConnections' },
-    { 'name' => 'PDBWritePool_pool_TotalConnections',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.TotalConnections' },
-    { 'name' => 'PDBWritePool_pool_Usage',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.Usage' },
-    { 'name' => 'PDBWritePool_pool_Wait',
-      'url'  => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.Wait' },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBReadPool_pool_ActiveConnections',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.ActiveConnections'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBReadPool_pool_IdleConnections',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.IdleConnections'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBReadPool_pool_PendingConnections',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.PendingConnections'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBReadPool_pool_TotalConnections',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.TotalConnections'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBReadPool_pool_Usage',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.Usage'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBReadPool_pool_Wait',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBReadPool.pool.Wait'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBWritePool_pool_ActiveConnections',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.ActiveConnections'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBWritePool_pool_IdleConnections',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.IdleConnections'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBWritePool_pool_PendingConnections',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.PendingConnections'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBWritePool_pool_TotalConnections',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.TotalConnections'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBWritePool_pool_Usage',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.Usage'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'PDBWritePool_pool_Wait',
+      'mbean' => 'puppetlabs.puppetdb.database:name=PDBWritePool.pool.Wait'
+    }
   ]
 
   $ha_sync_metrics = [
-    { 'name' => 'ha_last-sync-succeeded',
-      'url'  => 'puppetlabs.puppetdb.ha:name=last-sync-succeeded' },
-    { 'name' => 'ha_seconds-since-last-successful-sync',
-      'url'  => 'puppetlabs.puppetdb.ha:name=seconds-since-last-successful-sync' },
-    { 'name' => 'ha_failed-request-counter',
-      'url'  => 'puppetlabs.puppetdb.ha:name=failed-request-counter' },
-    { 'name' => 'ha_sync-duration',
-      'url'  => 'puppetlabs.puppetdb.ha:name=sync-duration' },
-    { 'name' => 'ha_catalogs-sync-duration',
-      'url'  => 'puppetlabs.puppetdb.ha:name=catalogs-sync-duration' },
-    { 'name' => 'ha_reports-sync-duration',
-      'url'  => 'puppetlabs.puppetdb.ha:name=reports-sync-duration' },
-    { 'name' => 'ha_factsets-sync-duration',
-      'url'  => 'puppetlabs.puppetdb.ha:name=factsets-sync-duration' },
-    { 'name' => 'ha_nodes-sync-duration',
-      'url'  => 'puppetlabs.puppetdb.ha:name=nodes-sync-duration' },
-    { 'name' => 'ha_record-transfer-duration',
-      'url'  => 'puppetlabs.puppetdb.ha:name=record-transfer-duration' },
+    {
+      'type'  => 'read',
+      'name'  => 'ha_last-sync-succeeded',
+      'mbean' => 'puppetlabs.puppetdb.ha:name=last-sync-succeeded'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'ha_seconds-since-last-successful-sync',
+      'mbean' => 'puppetlabs.puppetdb.ha:name=seconds-since-last-successful-sync'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'ha_failed-request-counter',
+      'mbean' => 'puppetlabs.puppetdb.ha:name=failed-request-counter'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'ha_sync-duration',
+      'mbean' => 'puppetlabs.puppetdb.ha:name=sync-duration'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'ha_catalogs-sync-duration',
+      'mbean' => 'puppetlabs.puppetdb.ha:name=catalogs-sync-duration'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'ha_reports-sync-duration',
+      'mbean' => 'puppetlabs.puppetdb.ha:name=reports-sync-duration'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'ha_factsets-sync-duration',
+      'mbean' => 'puppetlabs.puppetdb.ha:name=factsets-sync-duration'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'ha_nodes-sync-duration',
+      'mbean' => 'puppetlabs.puppetdb.ha:name=nodes-sync-duration'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'ha_record-transfer-duration',
+      'mbean' => 'puppetlabs.puppetdb.ha:name=record-transfer-duration'
+    },
   ]
 
-  $additional_metrics = $::pe_server_version ? {
-    /^2015\./       => $activemq_metrics,
-    /^2016\.[45]\./ => $activemq_metrics + $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics + $ha_sync_metrics,
-    /^2016\./       => $activemq_metrics + $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics,
-    default         => $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics + $ha_sync_metrics,
-  }
+  $additional_metrics = $base_metrics + $storage_metrics + $connection_pool_metrics + $version_specific_metrics + $ha_sync_metrics
 
   $ssl = $hosts ? {
     ['127.0.0.1'] => false,
-    default         => true,
+    default       => true,
   }
 
   if $port == 8081 and $ssl == false {

--- a/manifests/service/puppetserver.pp
+++ b/manifests/service/puppetserver.pp
@@ -12,31 +12,6 @@ class puppet_metrics_collector::service::puppetserver (
   Optional[Integer]       $metrics_server_port      = $puppet_metrics_collector::metrics_server_port,
   Optional[String]        $metrics_server_db_name   = $puppet_metrics_collector::metrics_server_db_name,
   ) {
-  if ($facts['pe_server_version'] =~ NotUndef) and (versioncmp($facts['pe_server_version'], '2018.1.0') < 0) {
-    $additional_metrics = [
-      { 'name' => 'compiler.find_node',
-        'url'  => "puppetserver:name=puppetlabs.${::hostname}.compiler.find_node" },
-      { 'name' => 'puppetdb.query',
-        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.query" },
-      { 'name' => 'puppetdb.resource.search',
-        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.resource.search" },
-      { 'name' => 'puppetdb.facts.encode',
-        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.facts.encode" },
-      { 'name' => 'puppetdb.command.submit.replace facts',
-        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.replace facts" },
-      { 'name' => 'puppetdb.catalog.munge',
-        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.catalog.munge" },
-      { 'name' => 'puppetdb.command.submit.replace catalog',
-        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.replace catalog" },
-      { 'name' => 'puppetdb.report.convert_to_wire_format_hash',
-        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.report.convert_to_wire_format_hash" },
-      { 'name' => 'puppetdb.command.submit.store report',
-        'url'  => "puppetserver:name=puppetlabs.${::hostname}.puppetdb.command.submit.store report" },
-    ]
-  } else {
-    $additional_metrics = []
-  }
-
   puppet_metrics_collector::pe_metric { 'puppetserver' :
     metric_ensure            => $metrics_ensure,
     cron_minute              => "*/${collection_frequency}",
@@ -45,7 +20,7 @@ class puppet_metrics_collector::service::puppetserver (
     metrics_port             => $port,
     override_metrics_command => $override_metrics_command,
     excludes                 => $excludes,
-    additional_metrics       => $additional_metrics,
+    additional_metrics       => [],
     metrics_server_type      => $metrics_server_type,
     metrics_server_hostname  => $metrics_server_hostname,
     metrics_server_port      => $metrics_server_port,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-puppet_metrics_collector",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "author": "npwalker",
   "summary": "A Puppet module for gathering metrics from PE components",
   "license": "Apache-2.0",
@@ -17,7 +17,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -25,7 +24,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -33,21 +31,12 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
     },
     {
       "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "6",
         "7"
@@ -56,16 +45,15 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "10.04",
-        "12.04",
-        "14.04"
+        "16.04",
+        "18.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.2.1"
+      "version_requirement": ">= 5.5.1"
     }
   ],
   "pdk-version": "1.16.0",


### PR DESCRIPTION
With this commit ...

We switch from the v1 to v2 Metrics API for additional metrics (for PuppetDB),
and drop metrics for unsupported versions of PE.

(This is required in response to PE-28451 / PE-28468.

Note these additional metrics generate errors in PE 2019.4 via v2:

  puppetlabs.puppetdb.ha:name=failed-request-counter
  puppetlabs.puppetdb.mq:name=global.generate-retry-message-time
  puppetlabs.puppetdb.mq:name=global.retry-persistence-time