### PR TITLE
Allow for coalescing boolean values

### DIFF
--- a/files/pe_metrics.rb
+++ b/files/pe_metrics.rb
@@ -30,7 +30,7 @@ config_file = File.expand_path("../../config/#{options[:metrics_type]}.yaml", __
 config = YAML.load_file(config_file)
 
 def coalesce(higher_precedence, lower_precedence, default = nil)
-  [higher_precedence, lower_precedence].find{|x|!x.nil?} || default
+  [higher_precedence, lower_precedence, default].find{|x|!x.nil?}
 end
 
 METRICS_TYPE       = options[:metrics_type]


### PR DESCRIPTION
Prior to this commit, the coalesce method would not properly handle
boolean values. It would return the default `true` if coalescing a
`false` value. This commit updates the logic to be able to handle
booleans correctly.

This PR resolves #60 