### PR TITLE
Fix ensure => absent for metrics

### DIFF
--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -26,6 +26,8 @@ define puppet_metrics_collector::pe_metric (
 
   file { $metrics_output_dir :
     ensure => $metrics_output_dir_ensure,
+    # Allow directories to be removed.
+    force  => true,
   }
 
   $config_hash = {

--- a/manifests/sar_metric.pp
+++ b/manifests/sar_metric.pp
@@ -18,6 +18,8 @@ define puppet_metrics_collector::sar_metric (
 
   file { $metrics_output_dir :
     ensure => $metrics_output_dir_ensure,
+    # Allow directories to be removed.
+    force  => true,
   }
 
   $metric_script_file_path = "${puppet_metrics_collector::system::scripts_dir}/${metric_script_file}"


### PR DESCRIPTION
This commit updates the `pe_metric` and `sar_metric` types to use
`force => true` when ensuring to absent. This change allows non-empty
directories to be removed.