### PR TITLE
Fix duplicate declaration of common files

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,26 +36,34 @@ class puppet_metrics_collector (
   $config_dir  = "${output_dir}/config"
   $scripts_dir = "${output_dir}/scripts"
 
-  file { [$output_dir, $config_dir, $scripts_dir] :
-    ensure => directory,
+  # If the puppet_metrics_collector::system class is evaluted first,
+  # File[$output_dir] will already be defined along with common scripts.
+  if !defined(File[$output_dir]) {
+    file { [$output_dir, $scripts_dir]:
+      ensure => directory,
+    }
+
+    file { "${scripts_dir}/create-metrics-archive":
+      ensure => file,
+      mode   => '0755',
+      source => 'puppet:///modules/puppet_metrics_collector/create-metrics-archive'
+    }
+
+    file { "${scripts_dir}/metrics_tidy":
+      ensure => file,
+      mode   => '0744',
+      source => 'puppet:///modules/puppet_metrics_collector/metrics_tidy'
+    }
   }
 
-  file { "${scripts_dir}/create-metrics-archive":
-    ensure => file,
-    mode   => '0755',
-    source => 'puppet:///modules/puppet_metrics_collector/create-metrics-archive'
+  file { $config_dir:
+    ensure => directory,
   }
 
   file { "${scripts_dir}/json2timeseriesdb" :
     ensure => file,
     mode   => '0755',
     source => 'puppet:///modules/puppet_metrics_collector/json2timeseriesdb'
-  }
-
-  file { "${scripts_dir}/metrics_tidy":
-    ensure => file,
-    mode   => '0744',
-    source => 'puppet:///modules/puppet_metrics_collector/metrics_tidy'
   }
 
   file { "${scripts_dir}/pe_metrics.rb" :

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,4 +8,16 @@ describe 'puppet_metrics_collector' do
       it { is_expected.to compile }
     end
   end
+
+  context 'when puppet_metrics_collector::system is included first' do
+    let(:pre_condition) { 'include puppet_metrics_collector::system' }
+
+    it { is_expected.to compile }
+  end
+
+  context 'when puppet_metrics_collector::system is included last' do
+    let(:post_condition) { 'include puppet_metrics_collector::system' }
+
+    it { is_expected.to compile }
+  end
 end


### PR DESCRIPTION
If the `puppet_metrics_collector::system` class is evaluated before the
`puppet_metrics_collector` class, a duplicate declaration error will
occur for output directories and scripts that are common to both classes.
The `system` class has guard logic to prevent this issue, this commit
copies the same logic to the top-level `puppet_metrics_collector` class
and updates the tests to ensure both orderings compile.