### PR TITLE
(GH-81) Enable client ssl cert for metrics

### DIFF
--- a/files/pe_metrics.rb
+++ b/files/pe_metrics.rb
@@ -124,10 +124,11 @@ def retrieve_additional_metrics(host, port, use_ssl, metrics_type, metrics)
 
   host_url = generate_host_url(host, port, use_ssl)
 
+  metrics_array = []
   endpoint = "#{host_url}/metrics/v2/read"
   metrics_output = post_endpoint(endpoint, use_ssl, metrics.to_json)
+  return metrics_array if metrics_output.empty?
 
-  metrics_array = []
   metrics.each_index do |index|
     metric_name = metrics[index]['name']
     metric_data = metrics_output[index]

--- a/files/tk_metrics
+++ b/files/tk_metrics
@@ -1,7 +1,6 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 
-# Metrics endpoints for our Trapper Keeper services do not require a client certificate.
-USE_CLIENTCERT = false
+USE_CLIENTCERT = true
 
 require_relative 'pe_metrics'
 


### PR DESCRIPTION
Prior to this commit, all trapperkeeper metrics were not using the
client ssl certificate. With the changes in PE-28647 to enable
authentication in metrics collection, we now need to leverage the
`auth.conf` rules which require client ssl authentication. This commit
defaults to using the client ssl for all tk metrics.

Resolves #81 

This affects PuppetDB collection on both 2021 and 2019.8.5. This PR needs to be tested on previous versions to confirm it does not break the existing PuppetDB metrics collection.