### PR TITLE
(maint) Update to PDK 2.0, Puppet versions, and OSes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -464,11 +464,6 @@ Style/BlockComments:
   Enabled: false
 Style/BlockDelimiters:
   Enabled: false
-Style/BracesAroundHashParameters:
-  Description: |
-    Braces are actually required by Ruby 2.7 in order to disambiguate between
-    keword arguments and actual hash parameters. Removed in RuboCop v0.80.0.
-  Enabled: false
 Style/CaseEquality:
   Enabled: false
 Style/CharacterLiteral:

--- a/metadata.json
+++ b/metadata.json
@@ -56,7 +56,7 @@
       "version_requirement": ">= 5.5.1"
     }
   ],
-  "pdk-version": "1.18.1",
+  "pdk-version": "2.0.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
   "template-ref": "remotes/origin/master-0-ga58fd92"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -18,28 +18,32 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.1"
+      "version_requirement": ">= 5.5.1 < 8.0.0"
     }
   ],
   "pdk-version": "2.0.0",

--- a/spec/classes/puppet_metrics_collector_system_spec.rb
+++ b/spec/classes/puppet_metrics_collector_system_spec.rb
@@ -20,13 +20,13 @@ describe 'puppet_metrics_collector::system' do
     end
 
     context 'when vmware-toolbox-cmd is present on the PATH' do
-      let(:facts) { super().merge({puppet_metrics_collector: {have_vmware_tools: true}}) }
+      let(:facts) { super().merge(puppet_metrics_collector: {have_vmware_tools: true}) }
 
       it { is_expected.to contain_cron('vmware_metrics_collection').with_ensure('present') }
     end
 
     context 'when vmware-toolbox-cmd is not present on the PATH' do
-      let(:facts) { super().merge({puppet_metrics_collector: {have_vmware_tools: false}}) }
+      let(:facts) { super().merge(puppet_metrics_collector: {have_vmware_tools: false}) }
 
       it { is_expected.to contain_notify('vmware_tools_warning') }
       it { is_expected.to contain_cron('vmware_metrics_collection').with_ensure('absent') }


### PR DESCRIPTION
This PR updates to PDK 2.0, adds support for Puppet 7, and adds support for EL 8.