### PR TITLE
(maint) Increase upper limit on stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 2.6.0 < 7.0.0"
+      "version_requirement": ">= 2.6.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Prior to this commit, the limit for puppetlabs-stdlib was 7.0.0. stdlib
7.0.0 was recently released and is still compatible with this module.
This commit increased the upper limit for puppetlabs-stdlib to 8.0.0.