### PR TITLE
(PE-31705) Re-enable remote metric collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Table of Contents
 This module collects metrics provided by the status endpoints of Puppet Enterprise services.
 The metrics can be used to identify performance issues that may be addressed by performance tuning.
 
-> In PE 2018.1.13 and newer and PE 2019.4 and newer, the `/metrics/v1` endpoints are disabled by default and access to the `/metrics/v2` endpoints are restricted to localhost ... in response to CVE-2020-7943. 
-This module requires access those endpoints to collect additional metrics from PuppetDB, and those metrics will not be collected from remote PuppetDB hosts until these restricted are resolved.
-Refer to [Configuration for Distributed Metrics Collection](#Configuration-for-distributed-metrics-collection) for a workaround. 
+
+> For PE versions older than 2019.8.5, access to the `/metrics/v2` API endpoint is restricted to `localhost` as a mitigation for [CVE-2020-7943](https://puppet.com/security/cve/CVE-2020-7943/). This module requires access the `/metrics/v2` API to collect a complete set of performance metrics from PuppetDB. Refer to [Configuration for Distributed Metrics Collection](#Configuration-for-distributed-metrics-collection) for a workaround.
 
 
 ## Setup

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -10,6 +10,7 @@ define puppet_metrics_collector::pe_metric (
   Boolean                   $ssl                      = true,
   Array[String]             $excludes                 = puppet_metrics_collector::version_based_excludes($title),
   Array[Hash]               $additional_metrics       = [],
+  Optional[Boolean]         $remote_metrics_enabled   = lookup('puppet_metrics_collector::pe_metric::remote_metrics_enabled', {'default_value' => undef}), # lint:ignore:140chars
   Optional[String]          $override_metrics_command = undef,
   Optional[Enum['influxdb','graphite','splunk_hec']] $metrics_server_type = undef,
   Optional[String]          $metrics_server_hostname  = undef,
@@ -30,15 +31,28 @@ define puppet_metrics_collector::pe_metric (
     force  => true,
   }
 
+  $_remote_metrics_enabled = if $remote_metrics_enabled =~ Boolean {
+    $remote_metrics_enabled
+  } elsif fact('pe_server_version') =~ NotUndef {
+    if versioncmp(fact('pe_server_version'), '2019.8.5') >= 0 {
+      true
+    } else {
+      false
+    }
+  } else {
+    false
+  }
+
   $config_hash = {
-    'metrics_type'       => $metrics_type,
-    'pe_version'         => $facts['pe_server_version'],
-    'clientcert'         => $::clientcert,
-    'hosts'              => $hosts.sort(),
-    'metrics_port'       => $metrics_port,
-    'ssl'                => $ssl,
-    'excludes'           => $excludes,
-    'additional_metrics' => $additional_metrics,
+    'metrics_type'           => $metrics_type,
+    'pe_version'             => $facts['pe_server_version'],
+    'clientcert'             => $::clientcert,
+    'hosts'                  => $hosts.sort(),
+    'metrics_port'           => $metrics_port,
+    'ssl'                    => $ssl,
+    'excludes'               => $excludes,
+    'additional_metrics'     => $additional_metrics,
+    'remote_metrics_enabled' => $_remote_metrics_enabled,
   }
 
   file { "${puppet_metrics_collector::config_dir}/${metrics_type}.yaml" :

--- a/spec/defines/pe_metric_spec.rb
+++ b/spec/defines/pe_metric_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'puppet_metrics_collector::pe_metric' do
+  let(:title) { 'test-service' }
+  let(:params) {
+    {metrics_port: 9000}
+  }
+  # This define has an undeclared dependency on the main
+  # puppet_metrics_collector class.
+  let(:pre_condition) { 'include puppet_metrics_collector' }
+
+  it 'compiles with minimal parameters set' do
+    expect(subject).to compile
+  end
+
+  describe 'remote metric collection' do
+    it 'is disabled by default due to CVE-2020-7943' do
+      expect(subject).to contain_file('/opt/puppetlabs/puppet-metrics-collector/config/test-service.yaml').with_content(/remote_metrics_enabled: false/)
+    end
+
+    context 'when the PE version is 2019.8.5 or newer' do
+      let(:facts) {
+        {pe_server_version: '2019.8.5'}
+      }
+
+      it 'is enabled by default' do
+        expect(subject).to contain_file('/opt/puppetlabs/puppet-metrics-collector/config/test-service.yaml').with_content(/remote_metrics_enabled: true/)
+      end
+    end
+
+    context 'when the PE version is 2019.8.4 or older' do
+      let(:facts) {
+        {pe_server_version: '2019.8.4'}
+      }
+
+      it 'is disabled by default' do
+        expect(subject).to contain_file('/opt/puppetlabs/puppet-metrics-collector/config/test-service.yaml').with_content(/remote_metrics_enabled: false/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit updates the collection of metrics from JVM services,
Puppet Server, PuppetDB, etc., to allow remote collection of
data from the `/metrics/v2/api` if the PE version is 2019.8.5
or newer. Remote collection from this API was disabled due
to the fix for CVE-2020-7943, which caused the API to return
a failure response for requests that did not originate from
localhost.

The restriction may also be removed by setting the following
Hiera parameter, which may be useful for FOSS users or users
on older PE versions:

```
puppet_metrics_collector::pe_metric::remote_metrics_enabled: true
```