### PR TITLE
Clean up temp files when metrics_tidy exits cleanly

### DIFF
--- a/files/metrics_tidy
+++ b/files/metrics_tidy
@@ -9,6 +9,10 @@ fail() {
   exit 1
 }
 
+cleanup() {
+  rm "$tmp"
+}
+
 # Clone, i.e. preserve, original stdout using fd 3.
 exec 3>&1
 # Send stderr and stdout to a temp file
@@ -17,6 +21,9 @@ exec &>"$tmp"
 
 # Run the fail() method on error
 trap fail ERR
+
+# Otherwise cleanup
+trap cleanup EXIT
 
 while [[ $1 ]]; do
   case "$1" in


### PR DESCRIPTION
Although there is code in place to clean up the temp files when we exit with an error, there is nothing to clean up these files on a clean exit. Ironic for a script called metrics_tidy :)