### PR TITLE
(PE-31763) Remove the dependency on stdlib

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,4 @@
 ---
 fixtures:
   repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib"
     cron_core: "git://github.com/puppetlabs/puppetlabs-cron_core"

--- a/functions/hosts_with_pe_profile.pp
+++ b/functions/hosts_with_pe_profile.pp
@@ -22,6 +22,7 @@ function puppet_metrics_collector::hosts_with_pe_profile($profile) {
                type = 'Class' and
                title = 'Puppet_enterprise::Profile::${_profile}' and
                nodes { deactivated is null and expired is null }
+               order by certname
               }").map |$nodes| { $nodes['certname'] }
   }
   else {

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -47,7 +47,7 @@ define puppet_metrics_collector::pe_metric (
     'metrics_type'           => $metrics_type,
     'pe_version'             => $facts['pe_server_version'],
     'clientcert'             => $::clientcert,
-    'hosts'                  => $hosts.sort(),
+    'hosts'                  => $hosts,
     'metrics_port'           => $metrics_port,
     'ssl'                    => $ssl,
     'excludes'               => $excludes,

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -33,8 +33,8 @@ define puppet_metrics_collector::pe_metric (
 
   $_remote_metrics_enabled = if $remote_metrics_enabled =~ Boolean {
     $remote_metrics_enabled
-  } elsif fact('pe_server_version') =~ NotUndef {
-    if versioncmp(fact('pe_server_version'), '2019.8.5') >= 0 {
+  } elsif $facts.dig('pe_server_version') =~ NotUndef {
+    if versioncmp($facts.dig('pe_server_version'), '2019.8.5') >= 0 {
       true
     } else {
       false

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -51,7 +51,9 @@ class puppet_metrics_collector::system (
 
   if $facts['virtual'] == 'vmware' {
     if $manage_vmware_tools and ($system_metrics_ensure == 'present') {
-      ensure_packages([$vmware_tools_pkg])
+      package {$vmware_tools_pkg:
+        ensure => present,
+      }
     }
 
     file { "${scripts_dir}/vmware_metrics":

--- a/metadata.json
+++ b/metadata.json
@@ -8,10 +8,6 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-puppet_metrics_collector",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-puppet_metrics_collector/issues",
   "dependencies": [
-    {
-      "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 2.6.0 < 8.0.0"
-    }
   ],
   "operatingsystem_support": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -7,8 +7,7 @@
   "source": "https://github.com/puppetlabs/puppetlabs-puppet_metrics_collector",
   "project_page": "https://github.com/puppetlabs/puppetlabs-puppet_metrics_collector",
   "issues_url": "https://github.com/puppetlabs/puppetlabs-puppet_metrics_collector/issues",
-  "dependencies": [
-  ],
+  "dependencies": [],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",


### PR DESCRIPTION
Prior to this commit, this module required puppetlabs-stdlib to be
functional. This commit removes puppetlabs-stdlib as a depencency.