### PR TITLE
Add concurrent-depth to PuppetDB metrics

### DIFF
--- a/manifests/service/puppetdb.pp
+++ b/manifests/service/puppetdb.pp
@@ -67,6 +67,11 @@ class puppet_metrics_collector::service::puppetdb (
       'type'  => 'read',
       'name'  => 'global_processing-time',
       'mbean' => 'puppetlabs.puppetdb.mq:name=global.processing-time'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'global_concurrent-depth',
+      'mbean' => 'puppetlabs.puppetdb.mq:name=global.concurrent-depth'
     }
   ]
 


### PR DESCRIPTION
This PR adds the global.concurrent-depth mbean to the PuppetDB
metrics. The concurrent-depth shows the queue depth of the pending
command writes to disk.