### PR TITLE
Add PuppetDB Jetty thread metrics

### DIFF
--- a/manifests/service/puppetdb.pp
+++ b/manifests/service/puppetdb.pp
@@ -72,6 +72,11 @@ class puppet_metrics_collector::service::puppetdb (
       'type'  => 'read',
       'name'  => 'global_concurrent-depth',
       'mbean' => 'puppetlabs.puppetdb.mq:name=global.concurrent-depth'
+    },
+    {
+      'type'  => 'read',
+      'name'  => 'jetty-queuedthreadpool',
+      'mbean' => 'org.eclipse.jetty.util.thread:id=*,type=queuedthreadpool'
     }
   ]
 


### PR DESCRIPTION
Prior to this PR, there were no metrics around the jetty thread
pool. This PR adds additional metrics to collect the jetty
`queuedthreadpool` metrics. This allows for looking at the jetty thread
usage in PuppetDB.

Example:

```
                "jetty-queuedthreadpool": {
                    "org.eclipse.jetty.util.thread:id=0,type=queuedthreadpool": {
                        "availableReservedThreads": 2,
                        "busyThreads": 7,
                        "daemon": false,
                        "detailedDump": false,
                        "idleThreads": 1,
                        "idleTimeout": 60000,
                        "leasedThreads": 6,
                        "lowOnThreads": false,
                        "lowThreadsThreshold": 1,
                        "maxAvailableThreads": 194,
                        "maxLeasedThreads": 10,
                        "maxReservedThreads": 4,
                        "maxThreads": 200,
                        "minThreads": 8,
                        "name": "qtp1512214559",
                        "queueSize": 0,
                        "readyThreads": 3,
                        "reservedThreads": -1,
                        "state": "STARTED",
                        "stopTimeout": 30000,
                        "threads": 10,
                        "threadsPriority": 5,
                        "utilizationRate": 0.005154639175257732,
                        "utilizedThreads": 1
                    }
                },
```