### PR TITLE
Ensure puppetdb query ordering is alphabetical

### DIFF
--- a/functions/hosts_with_pe_profile.pp
+++ b/functions/hosts_with_pe_profile.pp
@@ -22,7 +22,7 @@ function puppet_metrics_collector::hosts_with_pe_profile($profile) {
                type = 'Class' and
                title = 'Puppet_enterprise::Profile::${_profile}' and
                nodes { deactivated is null and expired is null }
-               order by certname
+               order by certname asc
               }").map |$nodes| { $nodes['certname'] }
   }
   else {


### PR DESCRIPTION
Prior to this commit, the ordering returned by the puppetdb query could
be inconsistent as it was not in a specified order. This commit updates
the query to ensure there is an alphabetical order to the list returned.
This should help make the yaml file idempotent.

This fixes an issue where the yaml files are constantly changing the order of the servers.