### PR TITLE
Rework namevar of defined types

### DIFF
--- a/manifests/collect.pp
+++ b/manifests/collect.pp
@@ -17,44 +17,44 @@ define puppet_metrics_collector::collect (
     'absent'  => false,
   }
 
-  file {"/etc/systemd/system/${metrics_type}-metrics.service":
+  file {"/etc/systemd/system/puppet_${metrics_type}-metrics.service":
     ensure  => $metric_ensure,
     content => epp('puppet_metrics_collector/service.epp',
-      { 'service' => $metrics_type, 'metrics_command' => $metrics_command }
+      { 'service' => "puppet_${metrics_type}", 'metrics_command' => $metrics_command }
     ),
   }
-  file {"/etc/systemd/system/${metrics_type}-metrics.timer":
+  file {"/etc/systemd/system/puppet_${metrics_type}-metrics.timer":
     ensure  => $metric_ensure,
     content => epp('puppet_metrics_collector/timer.epp',
-      { 'service' => $metrics_type, 'minute' => $minute },
+      { 'service' => "puppet_${metrics_type}", 'minute' => $minute },
     ),
   }
 
-  file {"/etc/systemd/system/${metrics_type}-tidy.service":
+  file {"/etc/systemd/system/puppet_${metrics_type}-tidy.service":
     ensure  => $metric_ensure,
     content => epp('puppet_metrics_collector/tidy.epp',
-      { 'service' => $metrics_type, 'tidy_command' => $tidy_command }
+      { 'service' => "puppet_${metrics_type}", 'tidy_command' => $tidy_command }
     ),
   }
-  file {"/etc/systemd/system/${metrics_type}-tidy.timer":
+  file {"/etc/systemd/system/puppet_${metrics_type}-tidy.timer":
     ensure  => $metric_ensure,
     content => epp('puppet_metrics_collector/tidy_timer.epp',
-      { 'service' => $metrics_type }
+      { 'service' => "puppet_${metrics_type}" }
     ),
   }
 
-  service { "${metrics_type}-metrics.service":
+  service { "puppet_${metrics_type}-metrics.service":
   }
-  service { "${metrics_type}-metrics.timer":
+  service { "puppet_${metrics_type}-metrics.timer":
     ensure    => $service_ensure,
     enable    => $service_enable,
-    subscribe => File["/etc/systemd/system/${metrics_type}-metrics.timer"],
+    subscribe => File["/etc/systemd/system/puppet_${metrics_type}-metrics.timer"],
   }
 
-  service { "${metrics_type}-tidy.service": }
-  service { "${metrics_type}-tidy.timer":
+  service { "puppet_${metrics_type}-tidy.service": }
+  service { "puppet_${metrics_type}-tidy.timer":
     ensure    => $service_ensure,
     enable    => $service_enable,
-    subscribe => File["/etc/systemd/system/${metrics_type}-tidy.timer"],
+    subscribe => File["/etc/systemd/system/puppet_${metrics_type}-tidy.timer"],
   }
 }

--- a/manifests/service/ace.pp
+++ b/manifests/service/ace.pp
@@ -13,7 +13,7 @@ class puppet_metrics_collector::service::ace (
   Optional[Integer]       $metrics_server_port      = $puppet_metrics_collector::metrics_server_port,
   Optional[String]        $metrics_server_db_name   = $puppet_metrics_collector::metrics_server_db_name,
   ) {
-  puppet_metrics_collector::pe_metric { 'puppet_ace' :
+  puppet_metrics_collector::pe_metric { 'ace' :
     metric_ensure           => $metrics_ensure,
     cron_minute             => "0/${collection_frequency}",
     retention_days          => $retention_days,

--- a/manifests/service/bolt.pp
+++ b/manifests/service/bolt.pp
@@ -13,7 +13,7 @@ class puppet_metrics_collector::service::bolt (
   Optional[Integer]       $metrics_server_port      = $puppet_metrics_collector::metrics_server_port,
   Optional[String]        $metrics_server_db_name   = $puppet_metrics_collector::metrics_server_db_name,
   ) {
-  puppet_metrics_collector::pe_metric { 'puppet_bolt' :
+  puppet_metrics_collector::pe_metric { 'bolt' :
     metric_ensure           => $metrics_ensure,
     cron_minute             => "0/${collection_frequency}",
     retention_days          => $retention_days,

--- a/manifests/service/orchestrator.pp
+++ b/manifests/service/orchestrator.pp
@@ -13,7 +13,7 @@ class puppet_metrics_collector::service::orchestrator (
   Optional[Integer]       $metrics_server_port      = $puppet_metrics_collector::metrics_server_port,
   Optional[String]        $metrics_server_db_name   = $puppet_metrics_collector::metrics_server_db_name,
   ) {
-  puppet_metrics_collector::pe_metric { 'puppet_orchestrator' :
+  puppet_metrics_collector::pe_metric { 'orchestrator' :
     metric_ensure            => $metrics_ensure,
     cron_minute              => "0/${collection_frequency}",
     retention_days           => $retention_days,

--- a/manifests/service/puppetdb.pp
+++ b/manifests/service/puppetdb.pp
@@ -454,7 +454,7 @@ class puppet_metrics_collector::service::puppetdb (
     $_port = $port
   }
 
-  puppet_metrics_collector::pe_metric { 'puppet_puppetdb' :
+  puppet_metrics_collector::pe_metric { 'puppetdb' :
     metric_ensure            => $metrics_ensure,
     cron_minute              => "0/${collection_frequency}",
     retention_days           => $retention_days,

--- a/manifests/service/puppetserver.pp
+++ b/manifests/service/puppetserver.pp
@@ -13,7 +13,7 @@ class puppet_metrics_collector::service::puppetserver (
   Optional[Integer]       $metrics_server_port      = $puppet_metrics_collector::metrics_server_port,
   Optional[String]        $metrics_server_db_name   = $puppet_metrics_collector::metrics_server_db_name,
   ) {
-  puppet_metrics_collector::pe_metric { 'puppet_puppetserver' :
+  puppet_metrics_collector::pe_metric { 'puppetserver' :
     metric_ensure            => $metrics_ensure,
     cron_minute              => "0/${collection_frequency}",
     retention_days           => $retention_days,

--- a/manifests/system/cpu.pp
+++ b/manifests/system/cpu.pp
@@ -5,7 +5,7 @@ class puppet_metrics_collector::system::cpu (
   Integer $retention_days            = $puppet_metrics_collector::system::retention_days,
   Integer $polling_frequency_seconds = $puppet_metrics_collector::system::polling_frequency_seconds,
   ) {
-  puppet_metrics_collector::sar_metric { 'puppet_system_cpu' :
+  puppet_metrics_collector::sar_metric { 'system_cpu' :
     metric_ensure             => $metrics_ensure,
     cron_minute               => "0/${collection_frequency}",
     retention_days            => $retention_days,

--- a/manifests/system/memory.pp
+++ b/manifests/system/memory.pp
@@ -5,7 +5,7 @@ class puppet_metrics_collector::system::memory (
   Integer $retention_days            = $puppet_metrics_collector::system::retention_days,
   Integer $polling_frequency_seconds = $puppet_metrics_collector::system::polling_frequency_seconds,
   ) {
-  puppet_metrics_collector::sar_metric { 'puppet_system_memory' :
+  puppet_metrics_collector::sar_metric { 'system_memory' :
     metric_ensure             => $metrics_ensure,
     cron_minute               => "0/${collection_frequency}",
     retention_days            => $retention_days,

--- a/manifests/system/postgres.pp
+++ b/manifests/system/postgres.pp
@@ -30,7 +30,7 @@ class puppet_metrics_collector::system::postgres (
 
   $tidy_command = "${puppet_metrics_collector::system::scripts_dir}/metrics_tidy -d ${metrics_output_dir} -r ${retention_days}"
 
-  puppet_metrics_collector::collect {'puppet_postgres':
+  puppet_metrics_collector::collect {'postgres':
     metrics_command => $metrics_command,
     tidy_command    => $tidy_command,
     metric_ensure   => $metrics_ensure,

--- a/manifests/system/processes.pp
+++ b/manifests/system/processes.pp
@@ -5,7 +5,7 @@ class puppet_metrics_collector::system::processes (
   Integer $retention_days            = $puppet_metrics_collector::system::retention_days,
   Integer $polling_frequency_seconds = $puppet_metrics_collector::system::polling_frequency_seconds,
 ) {
-  puppet_metrics_collector::sar_metric { 'puppet_system_processes' :
+  puppet_metrics_collector::sar_metric { 'system_processes' :
     metric_ensure             => $metrics_ensure,
     cron_minute               => "0/${collection_frequency}",
     retention_days            => $retention_days,

--- a/manifests/system/vmware.pp
+++ b/manifests/system/vmware.pp
@@ -38,7 +38,7 @@ class puppet_metrics_collector::system::vmware (
     }
   }
 
-  puppet_metrics_collector::collect {'puppet_vmware':
+  puppet_metrics_collector::collect {'vmware':
     metrics_command => $metrics_command,
     tidy_command    => $tidy_command,
     metric_ensure   => $metrics_ensure,

--- a/spec/defines/pe_metric_spec.rb
+++ b/spec/defines/pe_metric_spec.rb
@@ -20,13 +20,13 @@ describe 'puppet_metrics_collector::pe_metric' do
   context 'when not capturing metrics' do
     let(:params) { super().merge({ metric_ensure: 'absent' }) }
 
-    it { is_expected.to contain_service('test-service-metrics.timer').with_ensure('stopped') }
+    it { is_expected.to contain_service('puppet_test-service-metrics.timer').with_ensure('stopped') }
   end
 
   context 'when customizing collection frequency' do
     let(:params) { super().merge({ cron_minute: '0/12' }) }
 
-    it { is_expected.to contain_file('/etc/systemd/system/test-service-metrics.timer').with_content(%r{OnCalendar=.*0\/12}) }
+    it { is_expected.to contain_file('/etc/systemd/system/puppet_test-service-metrics.timer').with_content(%r{OnCalendar=.*0\/12}) }
   end
 
   describe 'remote metric collection' do


### PR DESCRIPTION
Prior to this commit, we instantiated the pe_metric defined types with
"puppet_" in their title.  This created issues in the scripts related to
validating the names of the services and output directories.  This
commit changes the defined type to include the "puppet_" prefix.