### PR TITLE
(GH-108) Disable sysstat management by default

### DIFF
--- a/lib/facter/puppet_metrics_collector.rb
+++ b/lib/facter/puppet_metrics_collector.rb
@@ -17,6 +17,14 @@ Facter.add(:puppet_metrics_collector, type: :aggregate) do
     end
   end
 
+  chunk(:have_sysstat) do
+    if Facter::Core::Execution.which('sar')
+      { have_sysstat: true }
+    else
+      { have_sysstat: false }
+    end
+  end
+
   chunk(:pe_psql) do
     if File.executable?('/opt/puppetlabs/server/bin/psql')
       { have_pe_psql: true }

--- a/spec/acceptance/pe_metric_spec.rb
+++ b/spec/acceptance/pe_metric_spec.rb
@@ -1,18 +1,13 @@
 require 'spec_helper_acceptance'
 
-describe 'test default and system includes' do
+describe 'default includes' do
   before(:all) do
     pp = <<-MANIFEST
         include puppet_metrics_collector
-        include puppet_metrics_collector::system
         MANIFEST
     idempotent_apply(pp)
   end
-  it 'all puppet_* metric services should be active or inactive' do
-    run_shell('systemctl list-units --type=service | grep "puppet_.*metrics"') do |r|
-      expect(r.stdout).to match(%r{activ})
-    end
-  end
+
   context 'all of the timers are running' do
     it { expect(service('puppet_ace-metrics.timer')).to be_running }
     it { expect(service('puppet_ace-tidy.timer')).to be_running }
@@ -20,29 +15,20 @@ describe 'test default and system includes' do
     it { expect(service('puppet_bolt-tidy.timer')).to be_running }
     it { expect(service('puppet_orchestrator-metrics.timer')).to be_running }
     it { expect(service('puppet_orchestrator-tidy.timer')).to be_running }
-    it { expect(service('puppet_postgres-metrics.timer')).to be_running }
-    it { expect(service('puppet_postgres-tidy.timer')).to be_running }
     it { expect(service('puppet_puppetdb-metrics.timer')).to be_running }
     it { expect(service('puppet_puppetdb-tidy.timer')).to be_running }
     it { expect(service('puppet_puppetserver-metrics.timer')).to be_running }
     it { expect(service('puppet_puppetserver-tidy.timer')).to be_running }
-    it { expect(service('puppet_system_cpu-metrics.timer')).to be_running }
-    it { expect(service('puppet_system_cpu-tidy.timer')).to be_running }
-    it { expect(service('puppet_system_memory-metrics.timer')).to be_running }
-    it { expect(service('puppet_system_memory-tidy.timer')).to be_running }
-    it { expect(service('puppet_system_processes-metrics.timer')).to be_running }
-    it { expect(service('puppet_system_processes-tidy.timer')).to be_running }
   end
+
   it 'creates tidy services files' do
     files = run_shell('ls /etc/systemd/system/puppet_*-tidy.service').stdout
-    expect(files.split("\n").count).to eq(9)
+    expect(files.split("\n").count).to eq(5)
   end
+
   it 'creates the timer files' do
     files = run_shell('ls /etc/systemd/system/puppet_*-tidy.timer').stdout
-    expect(files.split("\n").count).to eq(9)
-  end
-  it 'sysstat package is installed' do
-    expect(package('sysstat')).to be_installed
+    expect(files.split("\n").count).to eq(5)
   end
 
   describe file('/opt/puppetlabs/puppet-metrics-collector/puppetserver/127.0.0.1') do

--- a/spec/acceptance/pe_system_spec.rb
+++ b/spec/acceptance/pe_system_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper_acceptance'
+
+describe 'system class' do
+  context 'sysstat not installed and not managed' do
+    before(:all) do
+      run_shell('puppet resource package sysstat ensure=absent')
+      pp = <<-MANIFEST
+          include puppet_metrics_collector::system
+          MANIFEST
+      # The notify makes this non idempotent
+      expect(apply_manifest(pp).exit_code).not_to eq(1)
+      expect(apply_manifest(pp).exit_code).not_to eq(1)
+    end
+
+    context 'postgres timers are running' do
+      it { expect(service('puppet_postgres-metrics.timer')).to be_running }
+      it { expect(service('puppet_postgres-tidy.timer')).to be_running }
+    end
+
+    it 'creates tidy service file for postgres' do
+      files = run_shell('ls /etc/systemd/system/puppet_postgres-tidy.service').stdout
+      expect(files.split("\n")).not_to be_empty
+    end
+
+    it 'creates the service file for postgres' do
+      files = run_shell('ls /etc/systemd/system/puppet_postgres-metrics.service').stdout
+      expect(files.split("\n")).not_to be_empty
+    end
+
+    it 'sysstat package is not installed by default' do
+      expect(package('sysstat')).not_to be_installed
+    end
+
+    it 'have_sysstat is false without the package installed' do
+      expect(host_inventory['facter']['puppet_metrics_collector']['have_sysstat']).to eq false
+    end
+  end
+
+  context 'sysstat installed and not managed' do
+    before(:all) do
+      run_shell('puppet resource package sysstat ensure=installed')
+      pp = <<-MANIFEST
+          include puppet_metrics_collector::system
+          MANIFEST
+      expect(apply_manifest(pp).exit_code).not_to eq(1)
+      expect(apply_manifest(pp).exit_code).not_to eq(1)
+    end
+
+    it 'system puppet_* metric services should be active or inactive' do
+      run_shell('systemctl list-units --type=service | grep "puppet_system.*metrics"') do |r|
+        expect(r.stdout).to match(%r{activ})
+      end
+    end
+
+    context 'system timers are running' do
+      it { expect(service('puppet_system_cpu-metrics.timer')).to be_running }
+      it { expect(service('puppet_system_cpu-tidy.timer')).to be_running }
+      it { expect(service('puppet_system_memory-metrics.timer')).to be_running }
+      it { expect(service('puppet_system_memory-tidy.timer')).to be_running }
+      it { expect(service('puppet_system_processes-metrics.timer')).to be_running }
+      it { expect(service('puppet_system_processes-tidy.timer')).to be_running }
+    end
+
+    it 'creates system tidy services files' do
+      files = run_shell('ls /etc/systemd/system/puppet_system*-tidy.service').stdout
+      expect(files.split("\n").count).to eq(3)
+    end
+  end
+
+  context 'managing sysstat' do
+    before(:all) do
+      pp = <<-MANIFEST
+          class { 'puppet_metrics_collector::system':
+            manage_sysstat => true,
+          }
+          MANIFEST
+      expect(apply_manifest(pp).exit_code).not_to eq(1)
+      expect(apply_manifest(pp).exit_code).not_to eq(1)
+    end
+
+    it 'sysstat package is installed' do
+      expect(package('sysstat')).to be_installed
+    end
+
+    it 'system puppet_* metric services should be active or inactive' do
+      run_shell('systemctl list-units --type=service | grep "puppet_system.*metrics"') do |r|
+        expect(r.stdout).to match(%r{activ})
+      end
+    end
+
+    context 'system timers are running' do
+      it { expect(service('puppet_system_cpu-metrics.timer')).to be_running }
+      it { expect(service('puppet_system_cpu-tidy.timer')).to be_running }
+      it { expect(service('puppet_system_memory-metrics.timer')).to be_running }
+      it { expect(service('puppet_system_memory-tidy.timer')).to be_running }
+      it { expect(service('puppet_system_processes-metrics.timer')).to be_running }
+      it { expect(service('puppet_system_processes-tidy.timer')).to be_running }
+    end
+
+    it 'creates system tidy services files' do
+      files = run_shell('ls /etc/systemd/system/puppet_system*-tidy.service').stdout
+      expect(files.split("\n").count).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
Prior to this PR, the default was to manage the sysstat package by
default. This PR changes the default to not manage the sysstat
package. It includes logic to only include the system metrics collection
classes when the sysstat package is installed and adds a notify when the
packge is not installed.

Resolves #108 