### PR TITLE
(maint) Add acceptance tests for the services

### DIFF
--- a/spec/acceptance/functions/hosts_with_pe_profile_spec.rb
+++ b/spec/acceptance/functions/hosts_with_pe_profile_spec.rb
@@ -7,7 +7,7 @@ describe 'hosts_with_pe_profile function' do
        notice "Received=$result"
        MANIFEST
     output = apply_manifest(pp).stdout
-    expect(output).to match(%r{127.0.0.1})
+    expect(output).to match(%r{Received=\[127.0.0.1\]})
   end
   it 'return the FQDN for the master profile' do
     # This influences the custom facts
@@ -17,7 +17,7 @@ describe 'hosts_with_pe_profile function' do
        notice "Received=$result"
        MANIFEST
     output = apply_manifest(pp).stdout
-    expect(output).to match(host_inventory['fqdn'])
+    expect(output).to match(%r{Received=\[#{host_inventory['fqdn']}\]})
     run_shell('puppet config set storeconfigs false --section user', expect_failures: false)
   end
 end

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -17,7 +17,7 @@ describe 'puppet_metrics_collector class' do
     end
     describe 'check puppet-metrics-collector directory' do
       it 'scripts folder exists' do
-        file('/opt/puppetlabs/puppet-metrics-collector/scripts').should be_directory
+        expect(file('/opt/puppetlabs/puppet-metrics-collector/scripts')).to be_directory
       end
     end
   end

--- a/spec/acceptance/pe_metric_spec.rb
+++ b/spec/acceptance/pe_metric_spec.rb
@@ -8,21 +8,90 @@ describe 'test default and system includes' do
         MANIFEST
     idempotent_apply(pp)
   end
-  it 'sets all puppet_* metric services to be active' do
+  it 'all puppet_* metric services should be active or inactive' do
     run_shell('systemctl list-units --type=service | grep "puppet_.*metrics"') do |r|
-      puts r.stdout
       expect(r.stdout).to match(%r{activ})
     end
   end
-  it 'check for the tidy services files' do
+  context 'all of the timers are running' do
+    it { expect(service('puppet_ace-metrics.timer')).to be_running }
+    it { expect(service('puppet_ace-tidy.timer')).to be_running }
+    it { expect(service('puppet_bolt-metrics.timer')).to be_running }
+    it { expect(service('puppet_bolt-tidy.timer')).to be_running }
+    it { expect(service('puppet_orchestrator-metrics.timer')).to be_running }
+    it { expect(service('puppet_orchestrator-tidy.timer')).to be_running }
+    it { expect(service('puppet_postgres-metrics.timer')).to be_running }
+    it { expect(service('puppet_postgres-tidy.timer')).to be_running }
+    it { expect(service('puppet_puppetdb-metrics.timer')).to be_running }
+    it { expect(service('puppet_puppetdb-tidy.timer')).to be_running }
+    it { expect(service('puppet_puppetserver-metrics.timer')).to be_running }
+    it { expect(service('puppet_puppetserver-tidy.timer')).to be_running }
+    it { expect(service('puppet_system_cpu-metrics.timer')).to be_running }
+    it { expect(service('puppet_system_cpu-tidy.timer')).to be_running }
+    it { expect(service('puppet_system_memory-metrics.timer')).to be_running }
+    it { expect(service('puppet_system_memory-tidy.timer')).to be_running }
+    it { expect(service('puppet_system_processes-metrics.timer')).to be_running }
+    it { expect(service('puppet_system_processes-tidy.timer')).to be_running }
+  end
+  it 'creates tidy services files' do
     files = run_shell('ls /etc/systemd/system/puppet_*-tidy.service').stdout
     expect(files.split("\n").count).to eq(9)
   end
-  it 'check for the timer files' do
+  it 'creates the timer files' do
     files = run_shell('ls /etc/systemd/system/puppet_*-tidy.timer').stdout
     expect(files.split("\n").count).to eq(9)
   end
-  it 'checks if sysstat package is installed' do
+  it 'sysstat package is installed' do
     expect(package('sysstat')).to be_installed
+  end
+
+  describe file('/opt/puppetlabs/puppet-metrics-collector/puppetserver/127.0.0.1') do
+    before(:each) { run_shell('systemctl start puppet_puppetserver-metrics.service') }
+
+    it { is_expected.to be_directory }
+    it 'contains metric files' do
+      files = run_shell('ls /opt/puppetlabs/puppet-metrics-collector/puppetserver/127.0.0.1/*').stdout
+      expect(files.split('\n')).not_to be_empty
+    end
+  end
+
+  describe file('/opt/puppetlabs/puppet-metrics-collector/puppetdb/127.0.0.1') do
+    before(:each) { run_shell('systemctl start puppet_puppetdb-metrics.service') }
+
+    it { is_expected.to be_directory }
+    it 'contains metric files' do
+      files = run_shell('ls /opt/puppetlabs/puppet-metrics-collector/puppetdb/127.0.0.1/*').stdout
+      expect(files.split('\n')).not_to be_empty
+    end
+  end
+
+  describe file('/opt/puppetlabs/puppet-metrics-collector/orchestrator/127.0.0.1') do
+    before(:each) { run_shell('systemctl start puppet_orchestrator-metrics.service') }
+
+    it { is_expected.to be_directory }
+    it 'contains metric files' do
+      files = run_shell('ls /opt/puppetlabs/puppet-metrics-collector/orchestrator/127.0.0.1/*').stdout
+      expect(files.split('\n')).not_to be_empty
+    end
+  end
+
+  describe file('/opt/puppetlabs/puppet-metrics-collector/ace/127.0.0.1') do
+    before(:each) { run_shell('systemctl start puppet_ace-metrics.service') }
+
+    it { is_expected.to be_directory }
+    it 'contains metric files' do
+      files = run_shell('ls /opt/puppetlabs/puppet-metrics-collector/ace/127.0.0.1/*').stdout
+      expect(files.split('\n')).not_to be_empty
+    end
+  end
+
+  describe file('/opt/puppetlabs/puppet-metrics-collector/bolt/127.0.0.1') do
+    before(:each) { run_shell('systemctl start puppet_bolt-metrics.service') }
+
+    it { is_expected.to be_directory }
+    it 'contains metric files' do
+      files = run_shell('ls /opt/puppetlabs/puppet-metrics-collector/bolt/127.0.0.1/*').stdout
+      expect(files.split('\n')).not_to be_empty
+    end
   end
 end


### PR DESCRIPTION
This commit adds some acceptance tests to validate the service status on
the timers, updates some naming conventions, and checks for metrics
collection.