### PR TITLE
(SUP-2493) Remove Puppet 5.x support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.1 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "2.1.1",


### PR DESCRIPTION
This commit removes Puppet 5.x support within the module. Puppet 5.x is
EOL and will no longer be tested in this module.