### PR TITLE
(maint) Remove Oracle 8 and Scientific 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -28,15 +28,13 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {


### PR DESCRIPTION
This commit removes OracleLinux-8 and Scientific-8 from the
metadata.json. These operating systems are not in facterdb and cannot be
tested.

Fixes these errors from the spec tests:

```
Warning: Cannot find image for OracleLinux-8
Warning: Cannot find image for Scientific-8
```