### PR TITLE
Change system notify to warning function

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -66,11 +66,9 @@ class puppet_metrics_collector::system (
     contain puppet_metrics_collector::system::cpu
     contain puppet_metrics_collector::system::memory
     contain puppet_metrics_collector::system::processes
-  } else {
-    notify { 'sysstat_missing_warning':
-      message  => 'System collection disabled. Set `puppet_metrics_collector::system::manage_sysstat: true` to enable system metrics',
-      loglevel => warning,
-    }
+  }
+  else {
+    warning('System collection disabled. Set `puppet_metrics_collector::system::manage_sysstat: true` to enable system metrics')
   }
 
   if $facts['virtual'] == 'vmware' {

--- a/spec/classes/puppet_metrics_collector_system_spec.rb
+++ b/spec/classes/puppet_metrics_collector_system_spec.rb
@@ -11,7 +11,6 @@ describe 'puppet_metrics_collector::system' do
       let(:pre_condition) { 'package{"sysstat": }' }
       let(:facts) { { puppet_metrics_collector: { have_sysstat: true, have_systemd: true } } }
 
-      it { is_expected.not_to contain_notify('sysstat_missing_warning') }
       it { is_expected.to contain_class('puppet_metrics_collector::system::cpu') }
       it { is_expected.to contain_class('puppet_metrics_collector::system::memory') }
       it { is_expected.to contain_class('puppet_metrics_collector::system::processes') }
@@ -21,7 +20,6 @@ describe 'puppet_metrics_collector::system' do
       let(:params) { { manage_sysstat: true } }
       let(:facts) { { puppet_metrics_collector: { have_sysstat: false, have_systemd: true } } }
 
-      it { is_expected.not_to contain_notify('sysstat_missing_warning') }
       it { is_expected.to contain_package('sysstat') }
       it { is_expected.to contain_class('puppet_metrics_collector::system::cpu') }
       it { is_expected.to contain_class('puppet_metrics_collector::system::memory') }
@@ -29,7 +27,6 @@ describe 'puppet_metrics_collector::system' do
     end
 
     context 'not installed and not managed' do
-      it { is_expected.to contain_notify('sysstat_missing_warning') }
       it { is_expected.not_to contain_package('sysstat') }
       it { is_expected.not_to contain_class('puppet_metrics_collector::system::cpu') }
       it { is_expected.not_to contain_class('puppet_metrics_collector::system::memory') }


### PR DESCRIPTION
Prior to this commit, the system manifest produced a notify event at
warning level if sysstat was unmanaged and uninstalled.  This caused
issues in idempotency testing, so this commit changes it to a WARN entry
in the server logs that does not produce an event.