### PR TITLE
(maint) Change default for hosts_with_pe_profile when storeconfigs is false

### DIFF
--- a/functions/hosts_with_pe_profile.pp
+++ b/functions/hosts_with_pe_profile.pp
@@ -30,7 +30,11 @@ function puppet_metrics_collector::hosts_with_pe_profile($profile) {
   }
 
   if empty($hosts) {
-    ['127.0.0.1']
+    $default = $facts['clientcert'] ? {
+      undef => '127.0.0.1',
+      default => $facts['clientcert']
+    }
+    [$default]
   }
   else {
     sort($hosts)

--- a/spec/acceptance/functions/hosts_with_pe_profile_spec.rb
+++ b/spec/acceptance/functions/hosts_with_pe_profile_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper_acceptance'
 
 describe 'hosts_with_pe_profile function' do
-  it 'returns 127.0.0.1 when no hosts are found' do
+  it 'returns the certname of the node when no hosts are found' do
     pp = <<-MANIFEST
        $result=puppet_metrics_collector::hosts_with_pe_profile('non_existant')
        notice "Received=$result"
        MANIFEST
     output = apply_manifest(pp).stdout
-    expect(output).to match(%r{Received=\[127.0.0.1\]})
+    expect(output).to match(%r{Received=\[#{host_inventory['fqdn']}\]})
   end
+
   it 'return the FQDN for the master profile' do
     # This influences the custom facts
     run_shell('puppet config set storeconfigs true --section user', expect_failures: false)
@@ -19,5 +20,16 @@ describe 'hosts_with_pe_profile function' do
     output = apply_manifest(pp).stdout
     expect(output).to match(%r{Received=\[#{host_inventory['fqdn']}\]})
     run_shell('puppet config set storeconfigs false --section user', expect_failures: false)
+  end
+
+  it 'returns the certname of the node when storeconfigs is false' do
+    # Should be set to false in the previous section
+    # In this case, the certname == fqdn, so we use that here
+    pp = <<-MANIFEST
+       $result=puppet_metrics_collector::hosts_with_pe_profile('master')
+       notice "Received=$result"
+       MANIFEST
+    output = apply_manifest(pp).stdout
+    expect(output).to match(%r{Received=\[#{host_inventory['fqdn']}\]})
   end
 end

--- a/spec/acceptance/pe_metric_spec.rb
+++ b/spec/acceptance/pe_metric_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper_acceptance'
 
+certname = host_inventory['fqdn']
 describe 'default includes' do
   before(:all) do
     pp = <<-MANIFEST
@@ -31,52 +32,52 @@ describe 'default includes' do
     expect(files.split("\n").count).to eq(5)
   end
 
-  describe file('/opt/puppetlabs/puppet-metrics-collector/puppetserver/127.0.0.1') do
+  describe file("/opt/puppetlabs/puppet-metrics-collector/puppetserver/#{certname}") do
     before(:each) { run_shell('systemctl start puppet_puppetserver-metrics.service') }
 
     it { is_expected.to be_directory }
     it 'contains metric files' do
-      files = run_shell('ls /opt/puppetlabs/puppet-metrics-collector/puppetserver/127.0.0.1/*').stdout
+      files = run_shell("ls /opt/puppetlabs/puppet-metrics-collector/puppetserver/#{certname}/*").stdout
       expect(files.split('\n')).not_to be_empty
     end
   end
 
-  describe file('/opt/puppetlabs/puppet-metrics-collector/puppetdb/127.0.0.1') do
+  describe file("/opt/puppetlabs/puppet-metrics-collector/puppetdb/#{certname}") do
     before(:each) { run_shell('systemctl start puppet_puppetdb-metrics.service') }
 
     it { is_expected.to be_directory }
     it 'contains metric files' do
-      files = run_shell('ls /opt/puppetlabs/puppet-metrics-collector/puppetdb/127.0.0.1/*').stdout
+      files = run_shell("ls /opt/puppetlabs/puppet-metrics-collector/puppetdb/#{certname}/*").stdout
       expect(files.split('\n')).not_to be_empty
     end
   end
 
-  describe file('/opt/puppetlabs/puppet-metrics-collector/orchestrator/127.0.0.1') do
+  describe file("/opt/puppetlabs/puppet-metrics-collector/orchestrator/#{certname}") do
     before(:each) { run_shell('systemctl start puppet_orchestrator-metrics.service') }
 
     it { is_expected.to be_directory }
     it 'contains metric files' do
-      files = run_shell('ls /opt/puppetlabs/puppet-metrics-collector/orchestrator/127.0.0.1/*').stdout
+      files = run_shell("ls /opt/puppetlabs/puppet-metrics-collector/orchestrator/#{certname}/*").stdout
       expect(files.split('\n')).not_to be_empty
     end
   end
 
-  describe file('/opt/puppetlabs/puppet-metrics-collector/ace/127.0.0.1') do
+  describe file("/opt/puppetlabs/puppet-metrics-collector/ace/#{certname}") do
     before(:each) { run_shell('systemctl start puppet_ace-metrics.service') }
 
     it { is_expected.to be_directory }
     it 'contains metric files' do
-      files = run_shell('ls /opt/puppetlabs/puppet-metrics-collector/ace/127.0.0.1/*').stdout
+      files = run_shell("ls /opt/puppetlabs/puppet-metrics-collector/ace/#{certname}/*").stdout
       expect(files.split('\n')).not_to be_empty
     end
   end
 
-  describe file('/opt/puppetlabs/puppet-metrics-collector/bolt/127.0.0.1') do
+  describe file("/opt/puppetlabs/puppet-metrics-collector/bolt/#{certname}") do
     before(:each) { run_shell('systemctl start puppet_bolt-metrics.service') }
 
     it { is_expected.to be_directory }
     it 'contains metric files' do
-      files = run_shell('ls /opt/puppetlabs/puppet-metrics-collector/bolt/127.0.0.1/*').stdout
+      files = run_shell("ls /opt/puppetlabs/puppet-metrics-collector/bolt/#{certname}/*").stdout
       expect(files.split('\n')).not_to be_empty
     end
   end


### PR DESCRIPTION
Previously, this would set the hosts to ['127.0.0.1'] when storeconfigs was false. This would cause flip flops when running puppet infra configure -> puppet agent -t.  This sets the default to the host certname, since this is what the value will end up being on the primary post-install, preventing this flip flop.