### PR TITLE
(SUP-2682) Remove Requires= property from timers

### DIFF
--- a/spec/acceptance/pe_system_spec.rb
+++ b/spec/acceptance/pe_system_spec.rb
@@ -46,12 +46,6 @@ describe 'system class' do
       expect(apply_manifest(pp).exit_code).not_to eq(1)
     end
 
-    it 'system puppet_* metric services should be active or inactive' do
-      run_shell('systemctl list-units --type=service | grep "puppet_system.*metrics"') do |r|
-        expect(r.stdout).to match(%r{activ})
-      end
-    end
-
     context 'system timers are running' do
       it { expect(service('puppet_system_cpu-metrics.timer')).to be_running }
       it { expect(service('puppet_system_cpu-tidy.timer')).to be_running }
@@ -80,12 +74,6 @@ describe 'system class' do
 
     it 'sysstat package is installed' do
       expect(package('sysstat')).to be_installed
-    end
-
-    it 'system puppet_* metric services should be active or inactive' do
-      run_shell('systemctl list-units --type=service | grep "puppet_system.*metrics"') do |r|
-        expect(r.stdout).to match(%r{activ})
-      end
     end
 
     context 'system timers are running' do

--- a/templates/tidy_timer.epp
+++ b/templates/tidy_timer.epp
@@ -1,7 +1,6 @@
 <%- | String $service | -%>
 [Unit]
 Description=Timer to tidy Puppet metrics
-Requires=<%= $service %>-tidy.service
 
 [Timer]
 OnCalendar=*-*-* 00:00:00

--- a/templates/timer.epp
+++ b/templates/timer.epp
@@ -1,7 +1,6 @@
 <%- | String $service, String $minute | -%>
 [Unit]
 Description=Timer to collect Puppet metrics
-Requires=<%= $service %>-metrics.service
 
 [Timer]
 OnCalendar=*-*-* *:<%= $minute %>


### PR DESCRIPTION
Prior to this commit, this property created an unwanted dependency
between the timer and service.  The effect is that starting the timer
will immediately start the service regardless of the schedule.  Removing
this property allows the implicit relationships to work properly.