### PR TITLE
(SUP-2725) Fix system collection frequency

### DIFF
--- a/manifests/system/postgres.pp
+++ b/manifests/system/postgres.pp
@@ -36,7 +36,7 @@ class puppet_metrics_collector::system::postgres (
     metrics_command => $metrics_command,
     tidy_command    => $tidy_command,
     metric_ensure   => $metrics_ensure,
-    minute          => String("0/${collection_frequency}"),
+    minute          => "0/${collection_frequency}",
     notify          => Exec['puppet_metrics_collector_system_daemon_reload'],
   }
 

--- a/manifests/system/vmware.pp
+++ b/manifests/system/vmware.pp
@@ -44,7 +44,7 @@ class puppet_metrics_collector::system::vmware (
     metrics_command => $metrics_command,
     tidy_command    => $tidy_command,
     metric_ensure   => $metrics_ensure,
-    minute          => String("0/${collection_frequency}"),
+    minute          => "0/${collection_frequency}",
     notify          => Exec['puppet_metrics_collector_system_daemon_reload'],
   }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -26,4 +26,12 @@ describe 'puppet_metrics_collector' do
 
     it { is_expected.to compile }
   end
+
+  context 'when customizing the collection frequency' do
+    let(:params) { { collection_frequency: 10 } }
+
+    ['ace', 'bolt', 'orchestrator', 'puppetdb', 'puppetserver'].each do |service|
+      it { is_expected.to contain_file("/etc/systemd/system/puppet_#{service}-metrics.timer").with_content(%r{OnCalendar=.*0\/10}) }
+    end
+  end
 end

--- a/spec/classes/puppet_metrics_collector_system_spec.rb
+++ b/spec/classes/puppet_metrics_collector_system_spec.rb
@@ -115,4 +115,16 @@ describe 'puppet_metrics_collector::system' do
 
     it { is_expected.not_to contain_puppet_metrics_collector__collect('system_cpu').with_metrics_command(%r{--influx-db\s+puppet_metrics}) }
   end
+
+  context 'when customizing the collection frequency' do
+    let(:facts) do
+      { puppet_metrics_collector: { have_vmware_tools: true, have_systemd: true, have_sysstat: true, have_pe_psql: true },
+        virtual: 'vmware' }
+    end
+    let(:params) { { collection_frequency: 10 } }
+
+    ['system_cpu', 'system_memory', 'system_processes', 'postgres', 'vmware'].each do |service|
+      it { is_expected.to contain_file("/etc/systemd/system/puppet_#{service}-metrics.timer").with_content(%r{OnCalendar=.*0\/10}) }
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, the postgres and vmware classes didn't correctly
set the 'minute' parameter of the defined type for collecting metrics.
They lack the "0/" prefix, meaning for a default value of 5 we are
performing the collections on the 5th minute, not repeating every 5
minutes.  This commit adds the prefix.