### PR TITLE
(GH-154) Switch from change time to modify time

### DIFF
--- a/files/create-metrics-archive
+++ b/files/create-metrics-archive
@@ -18,7 +18,7 @@ retention_days="${retention_days:-30}"
 timestamp="$(date +%Y.%m.%d.%H.%M.%S)"
 output_file="puppet-metrics-${timestamp}.tar.gz"
 
-find "$metrics_directory" -type f -ctime -"$retention_days" -and \( -name "*json" -or -name "*gz" \) | \
+find "$metrics_directory" -type f -mtime -"$retention_days" -and \( -name "*json" -or -name "*gz" \) | \
   tar --create --gzip --file "$output_file" --files-from - --transform "s,^${metrics_directory#/},puppet-metrics-${timestamp}," || {
     echo "Error: could not create metrics archive: $output_file from $metrics_directory"
     exit 1

--- a/files/metrics_tidy
+++ b/files/metrics_tidy
@@ -60,7 +60,7 @@ paths_regex="$(IFS='|'; echo "${valid_paths[*]}")"
 }
 
 # Delete files in a Puppet service metrics directory older than the retention period, in days.
-find "$metrics_directory" -type f -ctime +"$retention_days" -delete
+find "$metrics_directory" -type f -mtime +"$retention_days" -delete
 
 # Compress the remaining files in a Puppet service metrics directory.
 # Store the list of files in a temp file so that `tar` and `rm` will operate on the same files


### PR DESCRIPTION
Prior to this PR, the default was to tidy and archive json files using ctime. This was under the assumption it stood for 'creation time' (see #154). It instead means 'change time'. We care about modified time (mtime) so that the timer doesn't reset whenever the inode is touched, even when the contents remain.