### PR TITLE
(SUP-3472) Add file sync storage metric collection

### DIFF
--- a/lib/facter/puppet_metrics_collector.rb
+++ b/lib/facter/puppet_metrics_collector.rb
@@ -32,4 +32,9 @@ Facter.add(:puppet_metrics_collector, type: :aggregate) do
       { have_pe_psql: false }
     end
   end
+
+  chunk(:file_sync_storage_enabled) do
+    { file_sync_storage_enabled: (Puppet::FileSystem.exist?('/etc/puppetlabs/puppetserver/bootstrap.cfg') &&
+      Puppet::FileSystem.read('/etc/puppetlabs/puppetserver/bootstrap.cfg').include?('file-sync-storage-service')) }
+  end
 end


### PR DESCRIPTION
Prior to this change, the filesync storage metrics were excluded in all
cases, so there was no way to determine the timing of the filesync
storage operations. This change adds in three metrics for the filesync
storage service to measure the commits, pre-commit, and add-rm times.