### PR TITLE
(SUP-3681) Check for valid status key in metrics

### DIFF
--- a/files/pe_metrics.rb
+++ b/files/pe_metrics.rb
@@ -135,7 +135,7 @@ def retrieve_additional_metrics(host, port, use_ssl, metrics_type, metrics)
     metric_name = metrics[index]['name']
     metric_data = metrics_output[index]
 
-    metric_status = metrics_output.dig('status')
+    metric_status = metric_data ? metric_data.dig('status') : nil
     next unless metric_status
 
     if metric_status == 200

--- a/files/pe_metrics.rb
+++ b/files/pe_metrics.rb
@@ -134,13 +134,17 @@ def retrieve_additional_metrics(host, port, use_ssl, metrics_type, metrics)
   metrics.each_index do |index|
     metric_name = metrics[index]['name']
     metric_data = metrics_output[index]
-    if metric_data['status'] == 200
+
+    metric_status = metrics_output.dig('status')
+    next unless metric_status
+
+    if metric_status == 200
       metrics_array << { 'name' => metric_name, 'data' => metric_data['value'] }
-    elsif metric_data['status'] == 404
+    elsif metric_status == 404
       metrics_array << { 'name' => metric_name, 'data' => nil }
     else
       metric_mbean = metrics[index]['mbean']
-      $error_array << "HTTP Error #{metric_data['status']} for #{metric_mbean}"
+      $error_array << "HTTP Error #{metric_status} for #{metric_mbean}"
     end
   end
 


### PR DESCRIPTION
Prior to this commit, an authentication failure would return a single hash instead of an array of hashes, which caused an exception.  This commit uses dig() to check the status and skip nulls.