### PR TITLE
Fix hard-coded path to runuser command

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,2 @@
+---
+puppet_metrics_collector::system::runuser_path: '/usr/sbin/runuser'

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,0 +1,2 @@
+---
+puppet_metrics_collector::system::runuser_path: '/sbin/runuser'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,13 @@
+---
+version: 5
+
+defaults:  # Used for any hierarchy level that omits these keys.
+  datadir: data         # This path is relative to hiera.yaml's directory.
+  data_hash: yaml_data  # Use the built-in YAML backend.
+
+hierarchy:
+  - name: "osfamily"
+    paths:
+      - "os/%{facts.os.family}.yaml"
+  - name: 'common'
+    path: 'common.yaml'

--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -3,6 +3,9 @@
 # 
 # @param system_metrics_ensure 
 #   Whether to enable or disable the collection of System metrics. Valid values are 'present', and 'absent'. Default : 'present'
+
+# @param runuser_path
+#   Path to the runuser executable.  Provided by module data
 # 
 # @param output_dir
 #   The directory to write the metrics to. Default: '/opt/puppetlabs/puppet-metrics-collector'
@@ -30,6 +33,7 @@
 # @param metrics_server_db_name 
 # 
 class puppet_metrics_collector::system (
+  String  $runuser_path, # provided by module data
   String  $system_metrics_ensure     = 'present',
   String  $output_dir                = '/opt/puppetlabs/puppet-metrics-collector',
   Integer $collection_frequency      = 5, # minutes
@@ -116,9 +120,12 @@ class puppet_metrics_collector::system (
 
   if $facts.dig('puppet_metrics_collector', 'have_pe_psql') {
     file { "${scripts_dir}/psql_metrics":
-      ensure => file,
-      mode   => '0755',
-      source => 'puppet:///modules/puppet_metrics_collector/psql_metrics',
+      ensure         => file,
+      mode           => '0755',
+      content        => epp(
+        'puppet_metrics_collector/psql_metrics.epp',
+        runuser_path => $runuser_path,
+      ),
     }
 
     contain puppet_metrics_collector::system::postgres

--- a/spec/classes/puppet_metrics_collector_system_spec.rb
+++ b/spec/classes/puppet_metrics_collector_system_spec.rb
@@ -1,6 +1,26 @@
 require 'spec_helper'
 
 describe 'puppet_metrics_collector::system' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it {
+        is_expected.to compile
+
+        case facts[:os]['family']
+        when 'Debian'
+          is_expected.to contain_class('puppet_metrics_collector::system').with(
+            runuser_path: '/sbin/runuser',
+          )
+        else
+          is_expected.to contain_class('puppet_metrics_collector::system').with(
+            runuser_path: '/usr/sbin/runuser',
+          )
+        end
+      }
+    end
+  end
   context 'with default parameters' do
     it { is_expected.not_to contain_package('sysstat') }
     it { is_expected.not_to contain_package('open-vm-tools') }

--- a/templates/psql_metrics.epp
+++ b/templates/psql_metrics.epp
@@ -1,3 +1,4 @@
+<%- | String $runuser_path | -%>
 #!/opt/puppetlabs/puppet/bin/ruby
 # frozen_string_literal: true
 
@@ -149,7 +150,7 @@ module PuppetMetricsCollector
                       '--single-transaction', '--tuples-only', '--quiet']
       psql_command += ["--dbname=#{database}"] unless database.nil?
 
-      command_line = ['/usr/sbin/runuser', '-u', 'pe-postgres',
+      command_line = ['<%= $runuser_path %>', '-u', 'pe-postgres',
                       '--', *psql_command]
 
       env = { 'PGOPTIONS' => "-c statement_timeout=#{timeout}s",


### PR DESCRIPTION
Prior to this commit, psql_metrics used a hard-coded path to /usr/sbin/runuser.  However, Ubuntu 18.04 uses /sbin/runuser.  Newer versions (and Debian) seem to have both, but for now we'll use /sbin/runuser for the Debian family.  This commit adds module data to provide defaults for the new
puppet_metrics_collector::system::runuser_path param.