### PR TITLE
(SUP-3881) Add collection for PE console services

### DIFF
--- a/files/json2timeseriesdb
+++ b/files/json2timeseriesdb
@@ -210,6 +210,11 @@ def influx_tag_parser(tag)
     tag.delete('orchestrator')
   end
 
+  if tag.include? 'console'
+    tag_set = "#{tag_set}service=console,"
+    tag.delete('console')
+  end
+
   if tag.include? 'puppetserver'
     tag_set = "#{tag_set}service=puppetserver,"
     tag.delete('puppetserver')

--- a/files/metrics_tidy
+++ b/files/metrics_tidy
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+#shellcheck disable=SC2317
+
 fail() {
   # Restore stdout by pointing it to fd 3 and send any errors to it
   exec >&3

--- a/files/metrics_tidy
+++ b/files/metrics_tidy
@@ -43,7 +43,7 @@ done
 
 
 # Guard against deleting or archiving files outside of a Puppet service metrics directory.
-valid_paths=(puppetserver puppetdb orchestrator ace bolt activemq postgres system_processes system_memory system_cpu vmware)
+valid_paths=(puppetserver puppetdb orchestrator console ace bolt activemq postgres system_processes system_memory system_cpu vmware)
 
 # Arguments and defaults.
 metrics_directory="${metrics_directory:-/opt/puppetlabs/puppet-metrics-collector/puppetserver}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,16 @@
 # @param orchestrator_port
 #   Port to connect to orchestrator on. Default: '8143' 
 # 
+#
+# @param console_metrics_ensure
+#   Whether to enable or disable the collection of PE Console metrics. Valid values are 'present', and 'absent'. Default : 'present'
+#
+# @param console_hosts
+#   The list of console hosts to collect metrics from. Uses the hosts_with_pe_profile function to determine the list of hosts with the console profile.
+#
+# @param console_port
+#   Port to connect to console on. Default: '4433'
+#
 # @param ace_metrics_ensure 
 #   Whether to enable or disable the collection of Ace metrics. Valid values are 'present', and 'absent'. Default : 'present'
 # 
@@ -83,6 +93,8 @@
 #   An Array of metrics to exclude from the puppetdb metrics collection.
 # @param orchestrator_excludes
 #   An Array of metrics to exclude from the orchestrator_excludes metrics collection.
+# @param console_excludes
+#   An Array of metrics to exclude from the console_excludes metrics collection.
 # @param ace_excludes
 #   An Array of metrics to exclude from the ace_excludes metrics collection.
 # @param bolt_excludes
@@ -111,6 +123,9 @@ class puppet_metrics_collector (
   String                  $orchestrator_metrics_ensure = 'present',
   Array[String]           $orchestrator_hosts          = puppet_metrics_collector::hosts_with_pe_profile('orchestrator'),
   Integer                 $orchestrator_port           = 8143,
+  String                  $console_metrics_ensure      = 'present',
+  Array[String]           $console_hosts               = puppet_metrics_collector::hosts_with_pe_profile('console'),
+  Integer                 $console_port                = 4433,
   String                  $ace_metrics_ensure          = 'present',
   Array[String]           $ace_hosts                   = puppet_metrics_collector::hosts_with_pe_profile('ace_server'),
   Integer                 $ace_port                    = 44633,
@@ -125,6 +140,7 @@ class puppet_metrics_collector (
   Optional[Array[String]] $puppetserver_excludes       = undef,
   Optional[Array[String]] $puppetdb_excludes           = undef,
   Optional[Array[String]] $orchestrator_excludes       = undef,
+  Optional[Array[String]] $console_excludes            = undef,
   Optional[Array[String]] $ace_excludes                = undef,
   Optional[Array[String]] $bolt_excludes               = undef,
   Optional[Array[String]] $activemq_excludes           = undef,
@@ -194,6 +210,7 @@ class puppet_metrics_collector (
     include puppet_metrics_collector::service::puppetserver
     include puppet_metrics_collector::service::puppetdb
     include puppet_metrics_collector::service::orchestrator
+    include puppet_metrics_collector::service::console
     include puppet_metrics_collector::service::ace
     include puppet_metrics_collector::service::bolt
 

--- a/manifests/service/console.pp
+++ b/manifests/service/console.pp
@@ -1,0 +1,33 @@
+# @summary Collects console metrics
+#
+# @api private
+#
+class puppet_metrics_collector::service::console (
+  String                  $metrics_ensure           = $puppet_metrics_collector::console_metrics_ensure,
+  Integer                 $collection_frequency     = $puppet_metrics_collector::collection_frequency,
+  Integer                 $retention_days           = $puppet_metrics_collector::retention_days,
+  Array[String]           $hosts                    = $puppet_metrics_collector::console_hosts,
+  Integer                 $port                     = $puppet_metrics_collector::console_port,
+  Array[Hash]             $extra_metrics            = [],
+  Optional[String]        $override_metrics_command = $puppet_metrics_collector::override_metrics_command,
+  Optional[Array[String]] $excludes                 = $puppet_metrics_collector::console_excludes,
+  Optional[Enum['influxdb', 'graphite', 'splunk_hec']] $metrics_server_type = $puppet_metrics_collector::metrics_server_type,
+  Optional[String]        $metrics_server_hostname  = $puppet_metrics_collector::metrics_server_hostname,
+  Optional[Integer]       $metrics_server_port      = $puppet_metrics_collector::metrics_server_port,
+  Optional[String]        $metrics_server_db_name   = $puppet_metrics_collector::metrics_server_db_name,
+) {
+  puppet_metrics_collector::pe_metric { 'console' :
+    metric_ensure            => $metrics_ensure,
+    cron_minute              => "0/${collection_frequency}",
+    retention_days           => $retention_days,
+    hosts                    => $hosts,
+    metrics_port             => $port,
+    additional_metrics       => $extra_metrics,
+    override_metrics_command => $override_metrics_command,
+    excludes                 => $excludes,
+    metrics_server_type      => $metrics_server_type,
+    metrics_server_hostname  => $metrics_server_hostname,
+    metrics_server_port      => $metrics_server_port,
+    metrics_server_db_name   => $metrics_server_db_name,
+  }
+}

--- a/spec/acceptance/pe_metric_spec.rb
+++ b/spec/acceptance/pe_metric_spec.rb
@@ -16,6 +16,8 @@ describe 'default includes' do
     it { expect(service('puppet_bolt-tidy.timer')).to be_running }
     it { expect(service('puppet_orchestrator-metrics.timer')).to be_running }
     it { expect(service('puppet_orchestrator-tidy.timer')).to be_running }
+    it { expect(service('puppet_console-metrics.timer')).to be_running }
+    it { expect(service('puppet_console-tidy.timer')).to be_running }
     it { expect(service('puppet_puppetdb-metrics.timer')).to be_running }
     it { expect(service('puppet_puppetdb-tidy.timer')).to be_running }
     it { expect(service('puppet_puppetserver-metrics.timer')).to be_running }
@@ -24,12 +26,12 @@ describe 'default includes' do
 
   it 'creates tidy services files' do
     files = run_shell('ls /etc/systemd/system/puppet_*-tidy.service').stdout
-    expect(files.split("\n").count).to eq(5)
+    expect(files.split("\n").count).to eq(6)
   end
 
   it 'creates the timer files' do
     files = run_shell('ls /etc/systemd/system/puppet_*-tidy.timer').stdout
-    expect(files.split("\n").count).to eq(5)
+    expect(files.split("\n").count).to eq(6)
   end
 
   describe file("/opt/puppetlabs/puppet-metrics-collector/puppetserver/#{certname}") do
@@ -58,6 +60,16 @@ describe 'default includes' do
     it { is_expected.to be_directory }
     it 'contains metric files' do
       files = run_shell("ls /opt/puppetlabs/puppet-metrics-collector/orchestrator/#{certname}/*").stdout
+      expect(files.split('\n')).not_to be_empty
+    end
+  end
+
+  describe file("/opt/puppetlabs/puppet-metrics-collector/console/#{certname}") do
+    before(:each) { run_shell('systemctl start puppet_console-metrics.service') }
+
+    it { is_expected.to be_directory }
+    it 'contains metric files' do
+      files = run_shell("ls /opt/puppetlabs/puppet-metrics-collector/console/#{certname}/*").stdout
       expect(files.split('\n')).not_to be_empty
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -30,7 +30,7 @@ describe 'puppet_metrics_collector' do
   context 'when customizing the collection frequency' do
     let(:params) { { collection_frequency: 10 } }
 
-    ['ace', 'bolt', 'orchestrator', 'puppetdb', 'puppetserver'].each do |service|
+    ['ace', 'bolt', 'orchestrator', 'console', 'puppetdb', 'puppetserver'].each do |service|
       it { is_expected.to contain_file("/etc/systemd/system/puppet_#{service}-metrics.timer").with_content(%r{OnCalendar=.*0\/10}) }
     end
   end


### PR DESCRIPTION
Prior to this change, the metrics collector did not collect metrics from the PE console. This change adds metrics collection for the PE console services.