### PR TITLE
Make changelog generator work

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -63,4 +63,6 @@ Gemfile:
   optional:
     ":development":
     - gem: github_changelog_generator
-      version: '= 1.15.2'
+      version: '= 1.16.4'
+    - gem: concurrent-ruby
+      version: '= 1.1.10'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,8 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "voxpupuli-puppet-lint-plugins", '>= 3.0',                 require: false
-  gem "github_changelog_generator",                              require: false
+  gem "github_changelog_generator", '= 1.16.4',                  require: false
+  gem "concurrent-ruby", '= 1.1.10',                             require: false
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]

--- a/metadata.json
+++ b/metadata.json
@@ -56,7 +56,7 @@
       "version_requirement": ">= 6.16.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.5.0",
+  "pdk-version": "2.6.1",
   "template-url": "https://github.com/puppetlabs/pdk-templates#2.5.0",
   "template-ref": "tags/2.5.0-0-g369d483"
 }


### PR DESCRIPTION
Moves to the dev-tools container which has a proper build environment for ruby gems

Pins concurrent ruby to 1.1.10, this can be rolled back after PDK in dev tools goes to 2.6.1

pins latest change log generator