### PR TITLE
(SUP-4126) Fix file sync additional metrics

### DIFF
--- a/manifests/service/puppetserver.pp
+++ b/manifests/service/puppetserver.pp
@@ -25,17 +25,17 @@ class puppet_metrics_collector::service::puppetserver (
     {
       'type'  => 'read',
       'name'  => 'file-sync-storage-commit-timer',
-      'mbean' => 'puppetserver:name=puppetlabs.puppet.file-sync-storage.commit-timer'
+      'mbean' => 'puppetserver:name=puppetlabs.*.file-sync-storage.commit-timer'
     },
     {
       'type'  => 'read',
       'name'  => 'file-sync-storage-pre-commit-hook-timer',
-      'mbean' => 'puppetserver:name=puppetlabs.puppet.file-sync-storage.pre-commit-hook-timer'
+      'mbean' => 'puppetserver:name=puppetlabs.*.file-sync-storage.pre-commit-hook-timer'
     },
     {
       'type' => 'read',
       'name' => 'file-sync-storage-commit-add-rm-timer',
-      'mbean' => 'puppetserver:name=puppetlabs.puppet.file-sync-storage.commit-add-rm-timer'
+      'mbean' => 'puppetserver:name=puppetlabs.*.file-sync-storage.commit-add-rm-timer'
     },
   ]
 


### PR DESCRIPTION
Prior to this commit, the mbeans for the additional file sync storage metrics started with 'puppetserver:name=puppetlabs.puppet'; however, the object name of the mbeans include the hostname of the compiling server. This resulted in the api returning 404s and not collecting the metrics.

This commit replaces the 'puppet' part of the name with a glob, which should match correctly.