### PR TITLE
(SUP-4870) Exclude comidi-route-metrics from Console collection

### DIFF
--- a/functions/version_based_excludes.pp
+++ b/functions/version_based_excludes.pp
@@ -6,10 +6,14 @@
 function puppet_metrics_collector::version_based_excludes(
   String[1] $metrics_type,
 ) >> Array[String] {
-  if $metrics_type == 'puppetserver' {
-    ['file-sync-storage-service','pe-puppet-profiler','pe-master','pe-jruby-metrics']
-  }
-  else {
-    $excludes = []
+  case $metrics_type {
+    'puppetserver': {
+      # File Sync Storage includes a lot of detail that bloats file sizes.
+      # The pe-* metrics are legacy representations that only duplicate data.
+      ['file-sync-storage-service','pe-puppet-profiler','pe-master','pe-jruby-metrics']
+    }
+    default: {
+      []
+    }
   }
 }

--- a/functions/version_based_excludes.pp
+++ b/functions/version_based_excludes.pp
@@ -12,6 +12,12 @@ function puppet_metrics_collector::version_based_excludes(
       # The pe-* metrics are legacy representations that only duplicate data.
       ['file-sync-storage-service','pe-puppet-profiler','pe-master','pe-jruby-metrics']
     }
+    'console': {
+      # PE Console has a lot of parameterized routes that can result in
+      # hundreds of megabytes collected daily from the route metrics.
+      # This data can be extracted from the console access log if needed.
+      ['comidi-route-metrics']
+    }
     default: {
       []
     }


### PR DESCRIPTION
This commit updates the default configuration for Console metrics
collection to exclude the `comidi-route-metrics` dataset.
The console uses heavily parameterized API paths which can result
in this dataset containing several megabytes of information, most
of which is noise. This can consume several hundreds of megabytes
or gigabytes of storage for a day's worth of metrics and can lead
to disk space exhaustion if cleanup is not active.

If needed, this data can be recovered by analyzing the Console
access logs.