### PR TITLE
(PE-40346) Fix retrieve_additional_metrics error handling

### DIFF
--- a/files/pe_metrics.rb
+++ b/files/pe_metrics.rb
@@ -79,16 +79,7 @@ module PuppetX
       end
 
       def retrieve_additional_metrics(url, _metrics_type, metrics)
-        begin
-          json_data = metrics.to_json
-        rescue StandardError => e
-          STDERR.puts 'Failed to convert metrics to JSON.'
-          STDERR.puts "Error: #{e.message}"
-          STDERR.puts e.backtrace
-          return []
-        end
-
-        metrics_output = post_endpoint(url, json_data)
+        metrics_output = post_endpoint(url, metrics.to_json)
         return [] if metrics_output.empty?
 
         # For a status other than 200 or 404, add the HTTP code to the error array

--- a/files/pe_metrics.rb
+++ b/files/pe_metrics.rb
@@ -80,6 +80,15 @@ module PuppetX
 
       def retrieve_additional_metrics(url, _metrics_type, metrics)
         metrics_output = post_endpoint(url, metrics.to_json)
+
+        unless metrics_output.is_a?(Array)
+          STDERR.puts('ERROR request to %{url} returned data non-Array data of type %{class}: %{output}' %
+                      { url: url,
+                        class: metrics_output.class,
+                        output: metrics_output.to_s })
+          return []
+        end
+
         return [] if metrics_output.empty?
 
         # For a status other than 200 or 404, add the HTTP code to the error array


### PR DESCRIPTION
This commit adds a guard clause to the `retrieve_additional_metrics`
function in `pe_metrics.rb` that ensures the data returned from the
`/metrics` API is of type Array.

Non-conforming data is logged to stderr along with the URL queried
as non-Array responses typically contain error messages that inform
why the request failed.