### PR TITLE
Fix puppet-lint space_before_arrow and 140chars warnings

### DIFF
--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -75,11 +75,11 @@ define puppet_metrics_collector::pe_metric (
 
   # LEGACY CLEANUP
   cron { "${metrics_type}_metrics_collection" :
-    ensure  => absent,
+    ensure => absent,
   }
 
   cron { "${metrics_type}_metrics_tidy" :
-    ensure  => absent,
+    ensure => absent,
   }
 
   $metric_legacy_files = [

--- a/manifests/sar_metric.pp
+++ b/manifests/sar_metric.pp
@@ -23,7 +23,8 @@
 #   The script file to run to collect the metrics. Default: 'system_metrics'
 #
 # @param metrics_shipping_command
-#   The parameter that defines the command for the remote shipping of metrics. Default: '$puppet_metrics_collector::system::metrics_shipping_command'
+#   The parameter that defines the command for the remote shipping of metrics.
+#   Default: '$puppet_metrics_collector::system::metrics_shipping_command'
 define puppet_metrics_collector::sar_metric (
   String                    $metrics_type              = $title,
   Enum['absent', 'present'] $metric_ensure             = 'present',
@@ -79,11 +80,11 @@ define puppet_metrics_collector::sar_metric (
   # LEGACY CLEANUP
 
   cron { "${metrics_type}_metrics_tidy" :
-    ensure  => absent,
+    ensure => absent,
   }
 
   cron { "${metrics_type}_metrics_collection" :
-    ensure  => absent,
+    ensure => absent,
   }
 
   $metric_legacy_files = [


### PR DESCRIPTION
## Summary

CI's strict lint check (\`bundle exec rake lint\`) fails on \`main\` due to pre-existing \`puppet-lint\` warnings in \`manifests/pe_metric.pp\` and \`manifests/sar_metric.pp\`:

- \`space_before_arrow\`: two spaces before \`=>\` instead of one, in a couple of \`cron { ... }\` resources
- \`140chars\`: one doc-comment line over the 140-character limit

Found this while investigating why an unrelated PR (#209) was showing CI failures on files it never touched -- confirmed these warnings already exist on \`main\`'s own tree, independent of that PR.

## Change

- Fixed arrow alignment in the four \`cron\` resource declarations across both files.
- Wrapped the long \`@param metrics_shipping_command\` doc comment in \`sar_metric.pp\` onto two lines.

No behavior change. \`bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop\` (the exact command CI runs) now exits clean, and the full \`spec/classes\`+\`spec/defines\` suite (49 examples) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)